### PR TITLE
Fix duplicate profile fetch

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,7 +10,16 @@ import prettierPlugin from 'eslint-plugin-prettier';
 import globals from 'globals';
 
 export default [
-  { ignores: ['dist', 'eslint.config.js', 'vite.config.js'] },
+  {
+    ignores: [
+      'dist',
+      'eslint.config.js',
+      'vite.config.js',
+      'public/engines/**',
+      'tailwind.config.js',
+      'tailwindcss-version-shim.js',
+    ],
+  },
 
   // Flat presets that really *are* flat
   js.configs.recommended,

--- a/src/hooks/useProfile.tsx
+++ b/src/hooks/useProfile.tsx
@@ -96,13 +96,9 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  const setUsername = useCallback(
-    (username: string) => {
-      setProfile((p) => ({ ...p, username }));
-      if (username) fetchProfile(username);
-    },
-    [fetchProfile]
-  );
+  const setUsername = useCallback((username: string) => {
+    setProfile((p) => ({ ...p, username }));
+  }, []);
 
   // on mount or when profile.username changes
   useEffect(() => {

--- a/src/pages/drills/components/DrillCard/HistoryDots.tsx
+++ b/src/pages/drills/components/DrillCard/HistoryDots.tsx
@@ -2,6 +2,7 @@ import { formatDistanceToNow, parseISO } from 'date-fns';
 import { Tooltip } from 'flowbite-react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Check, X } from 'lucide-react';
+import type { ReactElement } from 'react';
 
 type HistoryEntry = {
   result: 'pass' | 'fail';
@@ -31,7 +32,7 @@ export function HistoryDots({ history }: HistoryDotsProps) {
           const key = entry ? entry.timestamp : `empty-${idx}`;
 
           // 4) Pre‐compute tooltip content / dot‐styles
-          let dotContent: JSX.Element;
+          let dotContent: ReactElement;
           if (!entry) {
             dotContent = (
               <div className="h-4 w-4 rounded-full border border-gray-600 bg-transparent" />


### PR DESCRIPTION
## Summary
- avoid double fetching user profile by simplifying `setUsername`
- ignore generated engine files in ESLint config
- fix JSX type error in `HistoryDots`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683f475bc1e4832a929daf7ecf71fa0e