### PR TITLE
Fix typo in AnalysisNode comment

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -82,7 +82,7 @@ export interface AnalysisNode {
   deltaCP: number; // evalCP - previous evalCP
   bestMoveUCI?: string; // UCI best move at this position
   pvLines?: PVLine[]; // top-N principal variation lines
-  depth: number; // stockfish depth for anlysis (int)
+  depth: number; // stockfish depth for analysis (int)
   mateIn?: number; // if applicable, mate-in-N
   playedMove?: string; // UCI move string (e.g. e2e4)
   san?: string; // SAN move string (e.g. e4)


### PR DESCRIPTION
## Summary
- fix spelling of "analysis" in `AnalysisNode` interface comment

## Testing
- `grep -R "anlysis" -n`


------
https://chatgpt.com/codex/tasks/task_e_683f4a646a8c832a8d8157a7580c9566