### PR TITLE
Add archived/mastered drill filters

### DIFF
--- a/src/api/drills.ts
+++ b/src/api/drills.ts
@@ -12,6 +12,7 @@ export interface DrillFilters {
   phases?: ('opening' | 'middle' | 'late' | 'endgame')[];
   heroResults?: ('win' | 'loss' | 'draw')[];
   opponent?: string; // substring, case-insensitive
+  include?: ('archived' | 'mastered')[];
 }
 
 export interface DrillHistoryPayload {
@@ -29,6 +30,7 @@ export async function getDrills({
   phases = [],
   heroResults = [],
   opponent = '',
+  include = [],
 }: DrillFilters) {
   const params = new URLSearchParams({
     username,
@@ -44,6 +46,8 @@ export async function getDrills({
   heroResults.forEach((r) => params.append('hero_results', r));
 
   if (opponent.trim()) params.append('opponent', opponent.trim());
+
+  include.forEach((inc) => params.append('include', inc));
 
   const res = await fetch(`${BASE_URL}/drills?${params.toString()}`);
   if (!res.ok) {

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useRef } from 'react';
+import { X } from 'lucide-react';
+
+interface ModalProps {
+  show: boolean;
+  onClose(): void;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function Modal({
+  show,
+  onClose,
+  children,
+  className = '',
+}: ModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!show) return;
+    const onKey = (e: KeyboardEvent) => e.key === 'Escape' && onClose();
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [show, onClose]);
+
+  useEffect(() => {
+    if (!show) return;
+    const onClick = (e: MouseEvent) => {
+      if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener('mousedown', onClick);
+    return () => document.removeEventListener('mousedown', onClick);
+  }, [show, onClose]);
+
+  useEffect(() => {
+    document.body.classList.toggle('overflow-hidden', show);
+    return () => document.body.classList.remove('overflow-hidden');
+  }, [show]);
+
+  if (!show) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-2 backdrop-blur-md">
+      <div
+        ref={modalRef}
+        className={`relative w-full max-w-md rounded-xl border border-gray-700 bg-black/80 p-6 shadow-xl ${className}`}
+      >
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          className="absolute top-4 right-4 text-gray-400 hover:text-white"
+        >
+          <X size={20} />
+        </button>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/drills/components/FilterModal.tsx
+++ b/src/pages/drills/components/FilterModal.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import Modal from '@/components/Modal';
+
+interface Props {
+  show: boolean;
+  onClose(): void;
+  excludeWins: boolean;
+  setExcludeWins: (v: boolean) => void;
+  includeArchived: boolean;
+  setIncludeArchived: (v: boolean) => void;
+  includeMastered: boolean;
+  setIncludeMastered: (v: boolean) => void;
+  ToggleSwitch: React.FC<{ checked: boolean; onChange: () => void }>;
+}
+
+export default function FilterModal({
+  show,
+  onClose,
+  excludeWins,
+  setExcludeWins,
+  includeArchived,
+  setIncludeArchived,
+  includeMastered,
+  setIncludeMastered,
+  ToggleSwitch,
+}: Props) {
+  return (
+    <Modal show={show} onClose={onClose}>
+      <h2 className="mb-4 text-lg font-semibold text-white">Filters</h2>
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-gray-300">Include games won</span>
+          <ToggleSwitch
+            checked={!excludeWins}
+            onChange={() => setExcludeWins(!excludeWins)}
+          />
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-gray-300">Include archived</span>
+          <ToggleSwitch
+            checked={includeArchived}
+            onChange={() => setIncludeArchived(!includeArchived)}
+          />
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-gray-300">Include mastered</span>
+          <ToggleSwitch
+            checked={includeMastered}
+            onChange={() => setIncludeMastered(!includeMastered)}
+          />
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/pages/drills/index.tsx
+++ b/src/pages/drills/index.tsx
@@ -4,9 +4,10 @@ import { useState } from 'react';
 import RangeSlider from 'react-range-slider-input';
 import { useNavigate } from 'react-router-dom';
 import { Badge, TextInput } from 'flowbite-react';
-import { RefreshCw } from 'lucide-react';
+import { RefreshCw, SlidersHorizontal } from 'lucide-react';
 
 import DrillList from './components/DrillList';
+import FilterModal from './components/FilterModal';
 import { useDrills } from './hooks/useDrills';
 import 'react-range-slider-input/dist/style.css';
 
@@ -78,6 +79,7 @@ export default function DrillsPage() {
   );
 
   const [search, setSearch] = useState('');
+  const [showFilters, setShowFilters] = useState(false);
   const debouncedSearch = useDebounce(search, 300);
 
   // slider->cp
@@ -175,30 +177,24 @@ export default function DrillsPage() {
           <div className="text-sm text-gray-600 sm:text-base">
             {`Showing ${drills.length} result${drills.length === 1 ? '' : 's'}`}
           </div>
-          <div className="flex flex-wrap items-center gap-4 text-gray-300">
-            <div className="flex items-center gap-2">
-              <span className="text-sm text-gray-600">Include games won</span>
-              <ToggleSwitch
-                checked={!excludeWins}
-                onChange={() => setExcludeWins(!excludeWins)}
-              />
-            </div>
-            <div className="flex items-center gap-2">
-              <span className="text-sm text-gray-600">Include archived</span>
-              <ToggleSwitch
-                checked={includeArchived}
-                onChange={() => setIncludeArchived(!includeArchived)}
-              />
-            </div>
-            <div className="flex items-center gap-2">
-              <span className="text-sm text-gray-600">Include mastered</span>
-              <ToggleSwitch
-                checked={includeMastered}
-                onChange={() => setIncludeMastered(!includeMastered)}
-              />
-            </div>
-          </div>
+          <button
+            onClick={() => setShowFilters(true)}
+            className="flex items-center gap-2 text-sm text-gray-300 hover:text-white"
+          >
+            <SlidersHorizontal className="h-4 w-4" /> Filters
+          </button>
         </div>
+        <FilterModal
+          show={showFilters}
+          onClose={() => setShowFilters(false)}
+          excludeWins={excludeWins}
+          setExcludeWins={setExcludeWins}
+          includeArchived={includeArchived}
+          setIncludeArchived={setIncludeArchived}
+          includeMastered={includeMastered}
+          setIncludeMastered={setIncludeMastered}
+          ToggleSwitch={ToggleSwitch}
+        />
         {/* List */}
         <DrillList
           drills={drills}

--- a/src/pages/drills/index.tsx
+++ b/src/pages/drills/index.tsx
@@ -68,6 +68,14 @@ export default function DrillsPage() {
     'drillExcludeWins',
     true
   );
+  const [includeArchived, setIncludeArchived] = useStickyValue<boolean>(
+    'drillIncludeArchived',
+    false
+  );
+  const [includeMastered, setIncludeMastered] = useStickyValue<boolean>(
+    'drillIncludeMastered',
+    false
+  );
 
   const [search, setSearch] = useState('');
   const debouncedSearch = useDebounce(search, 300);
@@ -83,6 +91,11 @@ export default function DrillsPage() {
   ];
 
   // **server filter object**
+  const includeFilters = [
+    includeArchived && ('archived' as const),
+    includeMastered && ('mastered' as const),
+  ].filter(Boolean) as Array<'archived' | 'mastered'>;
+
   const filters = {
     username,
     minEvalSwing: minCutoff,
@@ -92,6 +105,7 @@ export default function DrillsPage() {
       ? (['loss', 'draw'] as Array<'loss' | 'draw'>)
       : undefined,
     opponent: debouncedSearch || undefined,
+    include: includeFilters.length ? includeFilters : undefined,
     limit: 20,
     openingThreshold: 14,
   } as const;
@@ -161,12 +175,26 @@ export default function DrillsPage() {
           <div className="text-sm text-gray-600 sm:text-base">
             {`Showing ${drills.length} result${drills.length === 1 ? '' : 's'}`}
           </div>
-          <div className="flex flex-wrap items-center gap-2 text-gray-300">
-            <span className="text-sm text-gray-600">Include games won</span>
-            <div>
+          <div className="flex flex-wrap items-center gap-4 text-gray-300">
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-gray-600">Include games won</span>
               <ToggleSwitch
                 checked={!excludeWins}
                 onChange={() => setExcludeWins(!excludeWins)}
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-gray-600">Include archived</span>
+              <ToggleSwitch
+                checked={includeArchived}
+                onChange={() => setIncludeArchived(!includeArchived)}
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-gray-600">Include mastered</span>
+              <ToggleSwitch
+                checked={includeMastered}
+                onChange={() => setIncludeMastered(!includeMastered)}
               />
             </div>
           </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -133,6 +133,7 @@ export interface DrillPosition {
   opponent_rating: number;
   played_at: string;
   phase: 'opening' | 'middle' | 'late' | 'endgame';
+  archived: boolean;
   history: DrillHistory[];
 }
 


### PR DESCRIPTION
## Summary
- support 'archived' flag in `DrillPosition` types
- allow including archived or mastered drills in API requests
- expose includeArchived and includeMastered toggles in the Drills list

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840142aad80832aad6b52e4fe0a49f7