### PR TITLE
Refactor drills filters and cleanup components

### DIFF
--- a/src/pages/drills/components/DrillBanner.tsx
+++ b/src/pages/drills/components/DrillBanner.tsx
@@ -1,0 +1,68 @@
+// src/pages/drills/components/DrillBanner.tsx
+import React from 'react';
+import { Crosshair, RotateCcw } from 'lucide-react';
+
+interface Props {
+  expectedResult: 'win' | 'draw' | 'hold' | null;
+  drillResult: 'pass' | 'fail' | null;
+  reason: string | null;
+  setResetKey: React.Dispatch<React.SetStateAction<number>>;
+  onNext: () => void;
+}
+
+export default function DrillBanner({
+  expectedResult,
+  drillResult,
+  reason,
+  setResetKey,
+  onNext,
+}: Props) {
+  return (
+    <div className="flex w-full flex-col items-center space-y-2">
+      {/* Drill Goal Banner (only show before result) */}
+      {expectedResult && !drillResult && (
+        <div className="flex w-full items-center justify-center rounded border border-indigo-500 bg-indigo-900 px-4 py-2 text-center text-indigo-200">
+          <Crosshair className="mr-1 h-4 w-4 text-indigo-400" />
+          <span className="text-sm">
+            <span className="mr-1 font-bold text-white/80">Goal</span>
+            {expectedResult === 'win' && 'Convert the Win'}
+            {expectedResult === 'hold' && 'Defend like Gurkesh!'}
+            {expectedResult === 'draw' && 'Hold the Draw'}
+          </span>
+        </div>
+      )}
+
+      {/* Drill Result Banner */}
+      {drillResult && (
+        <div
+          className={`flex items-center justify-center space-x-2 rounded-md px-4 py-2 text-center text-sm font-medium ${
+            drillResult === 'pass'
+              ? 'border border-green-500 bg-green-900 text-green-100'
+              : 'border border-red-500 bg-red-900 text-red-100'
+          }`}
+        >
+          <span>
+            {drillResult === 'pass'
+              ? `✅ ${reason ?? 'You met the goal!'}`
+              : `❌ ${reason ?? 'Better luck next time.'}`}
+          </span>
+          {drillResult === 'fail' && (
+            <button
+              onClick={() => setResetKey((prev) => prev + 1)}
+              className="inline-flex items-center rounded-md bg-green-600 px-2 py-1 text-xs font-medium text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:outline-none"
+            >
+              <RotateCcw className="mr-1 h-3 w-3" />
+              Retry
+            </button>
+          )}
+          <button
+            onClick={onNext}
+            className="inline-flex items-center rounded-md bg-blue-600 px-2 py-1 text-xs font-medium text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:outline-none"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/drills/components/DrillList.tsx
+++ b/src/pages/drills/components/DrillList.tsx
@@ -27,7 +27,11 @@ export default function DrillList({ drills, loading, onStartDrill }: Props) {
     <div className="space-y-8 sm:space-y-12">
       {drills.map((d) => {
         return (
-          <DrillCard key={d.id} drill={d} onStartDrill={() => onStartDrill(d.id)} />
+          <DrillCard
+            key={d.id}
+            drill={d}
+            onStartDrill={() => onStartDrill(d.id)}
+          />
         );
       })}
     </div>

--- a/src/pages/drills/components/PlayDrill.tsx
+++ b/src/pages/drills/components/PlayDrill.tsx
@@ -1,20 +1,16 @@
 // src/pages/drills/components/PlayDrill.tsx
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Chessboard } from 'react-chessboard';
 import { Navigate, useNavigate, useParams } from 'react-router-dom';
 import { Chess, Square } from 'chess.js';
-import {
-  Archive,
-  Clipboard,
-  ClipboardCheck,
-  Crosshair,
-  RotateCcw,
-} from 'lucide-react';
+import { Archive, Clipboard, ClipboardCheck } from 'lucide-react';
 
 import EvalBar from '../../analyse/components/EvalBar';
+import { buildDrillFilters, readStickyFilters } from '../filterUtils';
 import useAutoMove from '../hooks/useAutoMove';
 import useBotPlayer from '../hooks/useBotPlayer';
 import ArchiveConfirmModal from './ArchiveConfirmModal';
+import DrillBanner from './DrillBanner';
 import { GameInfoBadges } from './DrillCard/GameInfoBadges';
 import { HistoryDots } from './DrillCard/HistoryDots';
 import { TimePhaseHeader } from './DrillCard/TimePhaseHeader';
@@ -134,55 +130,8 @@ export default function PlayDrill() {
       return;
     }
 
-    const thresholdOptions = [
-      1,
-      150,
-      225,
-      337,
-      500,
-      1000,
-      10000,
-      Infinity,
-    ] as const;
-    const getSticky = <T,>(key: string, def: T): T => {
-      try {
-        const raw = localStorage.getItem(`bf:params:${key}`);
-        return raw ? (JSON.parse(raw) as T) : def;
-      } catch {
-        return def;
-      }
-    };
-
-    const phaseFilter = getSticky<
-      'all' | 'opening' | 'middle' | 'late' | 'endgame'
-    >('drillPhaseFilter', 'all');
-    const excludeWins = getSticky<boolean>('drillExcludeWins', true);
-    const includeArchived = getSticky<boolean>('drillIncludeArchived', false);
-    const includeMastered = getSticky<boolean>('drillIncludeMastered', false);
-    const rangeIdx = getSticky<[number, number]>('drillRangeIdx', [
-      0,
-      thresholdOptions.length - 1,
-    ]);
-
-    const includeFilters = [
-      includeArchived && ('archived' as const),
-      includeMastered && ('mastered' as const),
-    ].filter(Boolean) as Array<'archived' | 'mastered'>;
-
-    const filters = {
-      username,
-      minEvalSwing: thresholdOptions[rangeIdx[0]],
-      maxEvalSwing: Number.isFinite(thresholdOptions[rangeIdx[1]])
-        ? thresholdOptions[rangeIdx[1]]
-        : undefined,
-      phases: phaseFilter === 'all' ? undefined : [phaseFilter],
-      heroResults: excludeWins
-        ? (['loss', 'draw'] as Array<'loss' | 'draw'>)
-        : undefined,
-      include: includeFilters.length ? includeFilters : undefined,
-      limit: 20,
-      openingThreshold: 14,
-    } as const;
+    const sticky = readStickyFilters();
+    const filters = buildDrillFilters(username, sticky);
 
     try {
       const drills = await getDrills(filters);
@@ -358,69 +307,6 @@ export default function PlayDrill() {
         />
       </div>
     </>
-  );
-}
-
-function DrillBanner({
-  expectedResult,
-  drillResult,
-  reason,
-  setResetKey,
-  onNext,
-}: {
-  expectedResult: 'win' | 'draw' | 'hold' | null;
-  drillResult: 'pass' | 'fail' | null;
-  reason: string | null;
-  setResetKey: React.Dispatch<React.SetStateAction<number>>;
-  onNext: () => void;
-}) {
-  return (
-    <div className="flex w-full flex-col items-center space-y-2">
-      {/* Drill Goal Banner (only show before result) */}
-      {expectedResult && !drillResult && (
-        <div className="flex w-full items-center justify-center rounded border border-indigo-500 bg-indigo-900 px-4 py-2 text-center text-indigo-200">
-          <Crosshair className="mr-1 h-4 w-4 text-indigo-400" />
-          <span className="text-sm">
-            <span className="mr-1 font-bold text-white/80">Goal</span>
-            {expectedResult === 'win' && 'Convert the Win'}
-            {expectedResult === 'hold' && 'Defend like Gurkesh!'}
-            {expectedResult === 'draw' && 'Hold the Draw'}
-          </span>
-        </div>
-      )}
-
-      {/* Drill Result Banner */}
-      {drillResult && (
-        <div
-          className={`flex items-center justify-center space-x-2 rounded-md px-4 py-2 text-center text-sm font-medium ${
-            drillResult === 'pass'
-              ? 'border border-green-500 bg-green-900 text-green-100'
-              : 'border border-red-500 bg-red-900 text-red-100'
-          }`}
-        >
-          <span>
-            {drillResult === 'pass'
-              ? `✅ ${reason ?? 'You met the goal!'}`
-              : `❌ ${reason ?? 'Better luck next time.'}`}
-          </span>
-          {drillResult === 'fail' && (
-            <button
-              onClick={() => setResetKey((prev) => prev + 1)}
-              className="inline-flex items-center rounded-md bg-green-600 px-2 py-1 text-xs font-medium text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:outline-none"
-            >
-              <RotateCcw className="mr-1 h-3 w-3" />
-              Retry
-            </button>
-          )}
-          <button
-            onClick={onNext}
-            className="inline-flex items-center rounded-md bg-blue-600 px-2 py-1 text-xs font-medium text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:outline-none"
-          >
-            Next
-          </button>
-        </div>
-      )}
-    </div>
   );
 }
 

--- a/src/pages/drills/filterUtils.ts
+++ b/src/pages/drills/filterUtils.ts
@@ -1,0 +1,82 @@
+// src/pages/drills/filterUtils.ts
+export const THRESHOLD_OPTIONS = [
+  1,
+  150,
+  225,
+  337,
+  500,
+  1000,
+  10000,
+  Infinity,
+] as const;
+
+export type PhaseFilter = 'all' | 'opening' | 'middle' | 'late' | 'endgame';
+
+export interface StickyFilters {
+  phaseFilter: PhaseFilter;
+  excludeWins: boolean;
+  includeArchived: boolean;
+  includeMastered: boolean;
+  rangeIdx: [number, number];
+}
+
+const PREFIX = 'bf:params:';
+
+export function readStickyValue<T>(key: string, def: T): T {
+  try {
+    const raw = localStorage.getItem(`${PREFIX}${key}`);
+    return raw ? (JSON.parse(raw) as T) : def;
+  } catch {
+    return def;
+  }
+}
+
+export function readStickyFilters(): StickyFilters {
+  return {
+    phaseFilter: readStickyValue<PhaseFilter>('drillPhaseFilter', 'all'),
+    excludeWins: readStickyValue<boolean>('drillExcludeWins', true),
+    includeArchived: readStickyValue<boolean>('drillIncludeArchived', false),
+    includeMastered: readStickyValue<boolean>('drillIncludeMastered', false),
+    rangeIdx: readStickyValue<[number, number]>('drillRangeIdx', [
+      0,
+      THRESHOLD_OPTIONS.length - 1,
+    ]),
+  };
+}
+
+import type { DrillFilters } from '@/api/drills';
+
+export function buildDrillFilters(
+  username: string,
+  sticky: StickyFilters,
+  opponent?: string
+): DrillFilters {
+  const {
+    phaseFilter,
+    excludeWins,
+    includeArchived,
+    includeMastered,
+    rangeIdx,
+  } = sticky;
+
+  const includeFilters = [
+    includeArchived && ('archived' as const),
+    includeMastered && ('mastered' as const),
+  ].filter(Boolean) as Array<'archived' | 'mastered'>;
+
+  return {
+    username,
+    minEvalSwing: THRESHOLD_OPTIONS[rangeIdx[0]],
+    maxEvalSwing: Number.isFinite(THRESHOLD_OPTIONS[rangeIdx[1]])
+      ? THRESHOLD_OPTIONS[rangeIdx[1]]
+      : undefined,
+    phases: phaseFilter === 'all' ? undefined : [phaseFilter],
+    heroResults: excludeWins
+      ? (['loss', 'draw'] as Array<'loss' | 'draw'>)
+      : undefined,
+    opponent: opponent || undefined,
+    include: includeFilters.length ? includeFilters : undefined,
+    limit: 20,
+    openingThreshold: 14,
+  };
+}


### PR DESCRIPTION
## Summary
- centralize drill filter logic in `filterUtils`
- extract `DrillBanner` into its own component
- refactor `PlayDrill` to use new helpers
- simplify `DrillsPage` with shared filter builder
- run eslint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684094f2d4b4832ab7deda7cdd4c883c