### PR TITLE
Add recent drills page

### DIFF
--- a/src/api/drills.ts
+++ b/src/api/drills.ts
@@ -56,6 +56,27 @@ export async function getDrills({
   return res.json() as Promise<DrillPosition[]>;
 }
 
+export interface RecentDrillOpts {
+  username: string;
+  limit?: number;
+  includeArchived?: boolean;
+}
+
+export async function getRecentDrills({
+  username,
+  limit = 20,
+  includeArchived = false,
+}: RecentDrillOpts) {
+  const params = new URLSearchParams({ username, limit: String(limit) });
+  if (includeArchived) params.append('include_archived', 'true');
+
+  const res = await fetch(`${BASE_URL}/drills/recent?${params.toString()}`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch recent drills: ${res.status}`);
+  }
+  return res.json() as Promise<DrillPosition[]>;
+}
+
 // Fetch single drill by ID
 export async function getDrill(id: number) {
   const res = await fetch(`${BASE_URL}/drills/${id}`);

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,9 +1,9 @@
 // src/components/Sidebar.jsx
-import { useEffect, useState } from 'react';
-import { NavLink, useLocation } from 'react-router-dom';
+import { useState } from 'react';
+import { NavLink } from 'react-router-dom';
 import { Drawer } from 'flowbite-react';
 import { motion } from 'framer-motion';
-import { ChevronDown } from 'lucide-react';
+import { Clock } from 'lucide-react';
 
 import EasterEggCredits, { useRapidTaps } from './EasterEggCredits';
 
@@ -11,17 +11,6 @@ import blunderLogoSvg from '@/assets/blunderfixer.svg';
 import { useProfile } from '@/hooks/useProfile';
 
 export default function Sidebar({ isSidebarOpen, closeSidebar }) {
-  const location = useLocation();
-  const [drillsOpen, setDrillsOpen] = useState(
-    location.pathname.startsWith('/drills')
-  );
-
-  useEffect(() => {
-    if (location.pathname.startsWith('/drills')) {
-      setDrillsOpen(true);
-    }
-  }, [location.pathname]);
-
   const mainNav = [
     {
       to: '/insights',
@@ -108,6 +97,12 @@ export default function Sidebar({ isSidebarOpen, closeSidebar }) {
     ),
   };
 
+  const recentDrillsNav = {
+    to: '/drills/recent',
+    label: 'Recent Drills',
+    Icon: Clock,
+  };
+
   const bottomNav = [
     {
       to: '/help',
@@ -183,10 +178,17 @@ export default function Sidebar({ isSidebarOpen, closeSidebar }) {
             </li>
           ))}
           <li>
-            <DropdownItem
-              nav={drillsNav}
-              open={drillsOpen}
-              toggle={() => setDrillsOpen((o) => !o)}
+            <LinkItem
+              to={drillsNav.to}
+              label={drillsNav.label}
+              Icon={drillsNav.Icon}
+            />
+          </li>
+          <li>
+            <LinkItem
+              to={recentDrillsNav.to}
+              label={recentDrillsNav.label}
+              Icon={recentDrillsNav.Icon}
             />
           </li>
         </ul>
@@ -244,67 +246,6 @@ function LinkItem({ to, label, Icon }) {
           >
             <Icon className="h-6 w-6 flex-shrink-0 text-gray-400 transition-colors" />
             <span className="ml-3">{label}</span>
-          </motion.div>
-        );
-      }}
-    </NavLink>
-  );
-}
-
-function DropdownItem({ nav, open, toggle }) {
-  const { label, Icon } = nav;
-  const base =
-    'group flex w-full items-center rounded-lg p-2 text-base font-medium transition-colors';
-  const active =
-    'bg-gray-200 text-blue-600 bg-gray-700 dark:text-white bg-green-900';
-  const idle =
-    'text-gray-900 hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700';
-
-  return (
-    <div>
-      <button
-        onClick={toggle}
-        className={`${base} ${open ? active : idle}`}
-        type="button"
-      >
-        <Icon className="h-6 w-6 flex-shrink-0 text-gray-400 transition-colors" />
-        <span className="ml-3 flex-1 text-left">{label}</span>
-        <ChevronDown
-          className={`h-4 w-4 transition-transform ${open ? 'rotate-180' : ''}`}
-        />
-      </button>
-      {open && (
-        <ul className="mt-1 space-y-1 pl-8">
-          <li>
-            <SubLinkItem to="/drills" label="All" />
-          </li>
-          <li>
-            <SubLinkItem to="/drills/recent" label="Recent" />
-          </li>
-        </ul>
-      )}
-    </div>
-  );
-}
-
-function SubLinkItem({ to, label }) {
-  return (
-    <NavLink to={to} end>
-      {({ isActive }) => {
-        const base =
-          'block rounded-lg p-2 text-sm font-medium transition-colors';
-        const active =
-          'bg-gray-200 text-blue-600 bg-gray-700 dark:text-white bg-green-900';
-        const idle =
-          'text-gray-400 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700';
-
-        return (
-          <motion.div
-            whileHover={{ scale: 1.05 }}
-            whileTap={{ scale: 0.95 }}
-            className={`${base} ${isActive ? active : idle}`}
-          >
-            {label}
           </motion.div>
         );
       }}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -78,6 +78,25 @@ export default function Sidebar({ isSidebarOpen, closeSidebar }) {
         </svg>
       ),
     },
+    {
+      to: '/drills/recent',
+      label: 'Recent',
+      Icon: ({ className }) => (
+        <svg
+          aria-hidden="true"
+          className={className}
+          fill="currentColor"
+          viewBox="0 0 20 20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            fillRule="evenodd"
+            d="M10 18a8 8 0 100-16 8 8 0 000 16zm-1-13a1 1 0 112 0v4.586l2.293 2.293a1 1 0 01-1.414 1.414L9 10.414V5z"
+            clipRule="evenodd"
+          />
+        </svg>
+      ),
+    },
     // {
     //   to: '/profile',
     //   label: 'Profile',

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,8 +1,9 @@
 // src/components/Sidebar.jsx
-import { useState } from 'react';
-import { NavLink } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { NavLink, useLocation } from 'react-router-dom';
 import { Drawer } from 'flowbite-react';
 import { motion } from 'framer-motion';
+import { ChevronDown } from 'lucide-react';
 
 import EasterEggCredits, { useRapidTaps } from './EasterEggCredits';
 
@@ -10,6 +11,17 @@ import blunderLogoSvg from '@/assets/blunderfixer.svg';
 import { useProfile } from '@/hooks/useProfile';
 
 export default function Sidebar({ isSidebarOpen, closeSidebar }) {
+  const location = useLocation();
+  const [drillsOpen, setDrillsOpen] = useState(
+    location.pathname.startsWith('/drills')
+  );
+
+  useEffect(() => {
+    if (location.pathname.startsWith('/drills')) {
+      setDrillsOpen(true);
+    }
+  }, [location.pathname]);
+
   const mainNav = [
     {
       to: '/insights',
@@ -59,44 +71,6 @@ export default function Sidebar({ isSidebarOpen, closeSidebar }) {
         </svg>
       ),
     },
-    {
-      to: '/drills',
-      label: 'Drills',
-      Icon: ({ className }) => (
-        <svg
-          aria-hidden="true"
-          className={className}
-          fill="currentColor"
-          viewBox="0 0 20 20"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            fillRule="evenodd"
-            d="M3 3a1 1 0 000 2v8a2 2 0 002 2h2.586l-1.293 1.293a1 1 0 101.414 1.414L10 15.414l2.293 2.293a1 1 0 001.414-1.414L12.414 15H15a2 2 0 002-2V5a1 1 0 100-2H3zm11.707 4.707a1 1 0 00-1.414-1.414L10 9.586 8.707 8.293a1 1 0 00-1.414 0l-2 2a1 1 0 101.414 1.414L8 10.414l1.293 1.293a1 1 0 001.414 0l4-4z"
-            clipRule="evenodd"
-          ></path>
-        </svg>
-      ),
-    },
-    {
-      to: '/drills/recent',
-      label: 'Recent',
-      Icon: ({ className }) => (
-        <svg
-          aria-hidden="true"
-          className={className}
-          fill="currentColor"
-          viewBox="0 0 20 20"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            fillRule="evenodd"
-            d="M10 18a8 8 0 100-16 8 8 0 000 16zm-1-13a1 1 0 112 0v4.586l2.293 2.293a1 1 0 01-1.414 1.414L9 10.414V5z"
-            clipRule="evenodd"
-          />
-        </svg>
-      ),
-    },
     // {
     //   to: '/profile',
     //   label: 'Profile',
@@ -113,6 +87,26 @@ export default function Sidebar({ isSidebarOpen, closeSidebar }) {
     //   ),
     // },
   ];
+
+  const drillsNav = {
+    to: '/drills',
+    label: 'Drills',
+    Icon: ({ className }) => (
+      <svg
+        aria-hidden="true"
+        className={className}
+        fill="currentColor"
+        viewBox="0 0 20 20"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          fillRule="evenodd"
+          d="M3 3a1 1 0 000 2v8a2 2 0 002 2h2.586l-1.293 1.293a1 1 0 101.414 1.414L10 15.414l2.293 2.293a1 1 0 001.414-1.414L12.414 15H15a2 2 0 002-2V5a1 1 0 100-2H3zm11.707 4.707a1 1 0 00-1.414-1.414L10 9.586 8.707 8.293a1 1 0 00-1.414 0l-2 2a1 1 0 101.414 1.414L8 10.414l1.293 1.293a1 1 0 001.414 0l4-4z"
+          clipRule="evenodd"
+        ></path>
+      </svg>
+    ),
+  };
 
   const bottomNav = [
     {
@@ -188,6 +182,13 @@ export default function Sidebar({ isSidebarOpen, closeSidebar }) {
               <LinkItem to={to} label={label} Icon={Icon} />
             </li>
           ))}
+          <li>
+            <DropdownItem
+              nav={drillsNav}
+              open={drillsOpen}
+              toggle={() => setDrillsOpen((o) => !o)}
+            />
+          </li>
         </ul>
 
         <ul className="mt-5 space-y-2 border-t border-gray-200 pt-5 dark:border-gray-700">
@@ -243,6 +244,67 @@ function LinkItem({ to, label, Icon }) {
           >
             <Icon className="h-6 w-6 flex-shrink-0 text-gray-400 transition-colors" />
             <span className="ml-3">{label}</span>
+          </motion.div>
+        );
+      }}
+    </NavLink>
+  );
+}
+
+function DropdownItem({ nav, open, toggle }) {
+  const { label, Icon } = nav;
+  const base =
+    'group flex w-full items-center rounded-lg p-2 text-base font-medium transition-colors';
+  const active =
+    'bg-gray-200 text-blue-600 bg-gray-700 dark:text-white bg-green-900';
+  const idle =
+    'text-gray-900 hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700';
+
+  return (
+    <div>
+      <button
+        onClick={toggle}
+        className={`${base} ${open ? active : idle}`}
+        type="button"
+      >
+        <Icon className="h-6 w-6 flex-shrink-0 text-gray-400 transition-colors" />
+        <span className="ml-3 flex-1 text-left">{label}</span>
+        <ChevronDown
+          className={`h-4 w-4 transition-transform ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+      {open && (
+        <ul className="mt-1 space-y-1 pl-8">
+          <li>
+            <SubLinkItem to="/drills" label="All" />
+          </li>
+          <li>
+            <SubLinkItem to="/drills/recent" label="Recent" />
+          </li>
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function SubLinkItem({ to, label }) {
+  return (
+    <NavLink to={to} end>
+      {({ isActive }) => {
+        const base =
+          'block rounded-lg p-2 text-sm font-medium transition-colors';
+        const active =
+          'bg-gray-200 text-blue-600 bg-gray-700 dark:text-white bg-green-900';
+        const idle =
+          'text-gray-400 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700';
+
+        return (
+          <motion.div
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.95 }}
+            className={`${base} ${isActive ? active : idle}`}
+          >
+            {label}
           </motion.div>
         );
       }}

--- a/src/pages/drills/RecentDrillsPage.tsx
+++ b/src/pages/drills/RecentDrillsPage.tsx
@@ -1,0 +1,46 @@
+import { useNavigate } from 'react-router-dom';
+import { RefreshCw } from 'lucide-react';
+
+import DrillList from './components/DrillList';
+import { useRecentDrills } from './hooks/useRecentDrills';
+
+import { useProfile } from '@/hooks/useProfile';
+
+export default function RecentDrillsPage() {
+  const navigate = useNavigate();
+  const {
+    profile: { username },
+  } = useProfile();
+
+  const { drills, loading, refreshing, error, reload } =
+    useRecentDrills(username);
+
+  return (
+    <div className="p-4 pt-8 2xl:ml-12">
+      <div className="mx-auto max-w-2xl space-y-4">
+        <div className="flex items-baseline justify-between">
+          <span className="inline-block py-0.5 text-xs font-semibold tracking-wider text-green-500 uppercase">
+            Recent Drills
+          </span>
+          <button
+            onClick={() => reload()}
+            disabled={refreshing || loading || !username}
+            className="inline-flex items-center rounded bg-gray-800 px-3 py-1 text-sm text-gray-300 hover:bg-gray-700 disabled:opacity-50"
+          >
+            <RefreshCw
+              className={`mr-2 ${refreshing && 'animate-spin'}`}
+              size={14}
+            />
+            {refreshing ? 'Fetching…' : loading ? 'Loading…' : 'Refresh'}
+          </button>
+        </div>
+        {error && <p className="text-red-500">{String(error)}</p>}
+        <DrillList
+          drills={drills}
+          loading={loading}
+          onStartDrill={(id) => navigate(`/drills/play/${id}`)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/drills/RecentDrillsPage.tsx
+++ b/src/pages/drills/RecentDrillsPage.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { RefreshCw } from 'lucide-react';
 
-import DrillList from './components/DrillList';
+import RecentDrillList from './components/RecentDrillList';
 import { useRecentDrills } from './hooks/useRecentDrills';
 
 import { useProfile } from '@/hooks/useProfile';
@@ -35,10 +35,10 @@ export default function RecentDrillsPage() {
           </button>
         </div>
         {error && <p className="text-red-500">{String(error)}</p>}
-        <DrillList
+        <RecentDrillList
           drills={drills}
           loading={loading}
-          onStartDrill={(id) => navigate(`/drills/play/${id}`)}
+          onPlay={(id) => navigate(`/drills/play/${id}`)}
         />
       </div>
     </div>

--- a/src/pages/drills/components/DrillList.tsx
+++ b/src/pages/drills/components/DrillList.tsx
@@ -9,7 +9,7 @@ import type { DrillPosition } from '@/types';
 interface Props {
   drills: DrillPosition[];
   loading: boolean;
-  onStartDrill: (id: number) => void;
+  onStartDrill: (id: number | string) => void;
 }
 
 export default function DrillList({ drills, loading, onStartDrill }: Props) {

--- a/src/pages/drills/components/RecentDrillList.tsx
+++ b/src/pages/drills/components/RecentDrillList.tsx
@@ -1,0 +1,27 @@
+import { Spinner } from 'flowbite-react';
+
+import RecentDrillRow from './RecentDrillRow';
+
+import type { DrillPosition } from '@/types';
+
+interface Props {
+  drills: DrillPosition[];
+  loading: boolean;
+  onPlay: (id: number) => void;
+}
+
+export default function RecentDrillList({ drills, loading, onPlay }: Props) {
+  if (loading) {
+    return <Spinner size="lg" className="mx-auto mt-16" />;
+  }
+  if (!drills.length) {
+    return <p className="mt-16 text-center text-gray-500">No recent drills.</p>;
+  }
+  return (
+    <ul className="space-y-2">
+      {drills.map((d) => (
+        <RecentDrillRow key={d.id} drill={d} onPlay={onPlay} />
+      ))}
+    </ul>
+  );
+}

--- a/src/pages/drills/components/RecentDrillList.tsx
+++ b/src/pages/drills/components/RecentDrillList.tsx
@@ -18,7 +18,7 @@ export default function RecentDrillList({ drills, loading, onPlay }: Props) {
     return <p className="mt-16 text-center text-gray-500">No recent drills.</p>;
   }
   return (
-    <ul className="space-y-2">
+    <ul className="space-y-6">
       {drills.map((d) => (
         <RecentDrillRow key={d.id} drill={d} onPlay={onPlay} />
       ))}

--- a/src/pages/drills/components/RecentDrillRow.tsx
+++ b/src/pages/drills/components/RecentDrillRow.tsx
@@ -1,28 +1,77 @@
 import { Chessboard } from 'react-chessboard';
+import { format, formatDistanceToNow, parseISO } from 'date-fns';
 import { Play } from 'lucide-react';
 
 import { GameInfoBadges } from './DrillCard/GameInfoBadges';
 import { HistoryDots } from './DrillCard/HistoryDots';
 
+import type { DrillPosition } from '@/types';
+
+interface Props {
+  drill: DrillPosition;
+  onPlay: (id: number | string) => void;
+}
+
+export default function RecentDrillRow({ drill, onPlay }: Props) {
+  const orientation = drill.ply % 2 === 1 ? 'black' : 'white';
+
+  const last = [...drill.history].sort(
+    (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+  )[0];
+
+  const resultLabel = last ? (
+    last.result === 'pass' ? (
+      'Passed'
+    ) : (
+      'Failed'
+    )
+  ) : (
+    <i>Skipped</i>
+  );
+  const resultColor = last
+    ? last.result === 'pass'
+      ? 'text-green-400'
+      : 'text-red-500'
+    : 'text-gray-400';
+
+  const drilledDate = drill.last_drilled_at
+    ? parseISO(drill.last_drilled_at)
+    : null;
+  const dateStr = drilledDate
+    ? formatDistanceToNow(drilledDate, { addSuffix: true }).replace(
+        /^about\s*/,
+        ''
+      )
+    : '';
+  const absolute = drilledDate ? format(drilledDate, 'yyyy-MM-dd HH:mm') : '';
+
+  return (
+    <li className="flex items-center gap-2 rounded-lg bg-gray-800">
       <div className="shrink-0">
         <Chessboard
           position={drill.fen}
           boardOrientation={orientation}
           arePiecesDraggable={false}
-          boardWidth={120}
+          boardWidth={160}
           customBoardStyle={{ borderRadius: '0.5rem' }}
           customDarkSquareStyle={{ backgroundColor: '#B1B7C8' }}
           customLightSquareStyle={{ backgroundColor: '#F5F2E6' }}
         />
       </div>
-      <div className="flex flex-1 flex-col gap-1 overflow-hidden">
+      <div className="verflow-hidden flex flex-1 flex-col p-4">
         <div className="flex items-baseline justify-between">
-          <span className={`text-sm font-semibold ${resultColor}`}>
-            {resultLabel}
+          <span className={`text-sm text-gray-200`}>
+            <div className="xs:text-xs mt-2 text-sm font-bold text-green-400 uppercase sm:text-xs">
+              Last Attempt
+            </div>
+            {resultLabel} – <i>{drill.history.at(-1)?.reason}</i>
+          </span>
           {dateStr && (
             <time className="text-xs text-gray-400" dateTime={absolute}>
               {dateStr}
             </time>
+          )}
+        </div>
         <GameInfoBadges
           timeClass={drill.time_class}
           timeControl={drill.time_control}
@@ -33,48 +82,18 @@ import { HistoryDots } from './DrillCard/HistoryDots';
           evalSwing={drill.eval_swing}
           heroResult={drill.hero_result}
         />
-        <HistoryDots history={drill.history} />
-          boardOrientation={orientation}
-          arePiecesDraggable={false}
-          boardWidth={120}
-          customBoardStyle={{ borderRadius: '0.5rem' }}
-          customDarkSquareStyle={{ backgroundColor: '#B1B7C8' }}
-          customLightSquareStyle={{ backgroundColor: '#F5F2E6' }}
-        />
-      </div>
-
-      {/* Info */}
-      <div className="flex flex-col justify-between space-y-1 overflow-hidden text-sm">
-        <TimePhaseHeader
-          playedAt={game_played_at}
-          displayPhase={displayPhase}
-          phaseColor={phaseColor}
-        />
-
-        <div className="flex items-center gap-2 text-xs">
-          <span className={`rounded px-2 py-0.5 text-white ${resultColor}`}>
-            {resultLabel}
-          </span>
-          {reason && <span className="truncate text-gray-300">{reason}</span>}
-          {mastered && (
-            <span className="text-xs font-semibold text-green-400 uppercase">
-              Mastered
-            </span>
-          )}
+        <div className="xs:text-xs mt-2 text-sm font-bold text-gray-400 uppercase sm:text-xs">
+          Last 5 Tries
         </div>
-
-        <HistoryDots history={history} />
-      </div>
-
-      {/* Action */}
-      <div className="flex h-full items-end">
-        <button
-          onClick={() => onPlay(drill.id)}
-          className="inline-flex items-center gap-1 rounded bg-green-600 px-3 py-1 text-sm font-semibold text-white hover:bg-green-700"
-        >
-          <Play size={14} />
-          Drill
-        </button>
+        <div className="flex items-center justify-between">
+          <HistoryDots history={drill.history} />
+          <button
+            onClick={() => onPlay(drill.id)}
+            className="ml-2 inline-flex items-center gap-1 rounded bg-green-600 px-2 py-1 text-sm text-white hover:bg-green-700"
+          >
+            Retry <Play size={14} />
+          </button>
+        </div>
       </div>
     </li>
   );

--- a/src/pages/drills/components/RecentDrillRow.tsx
+++ b/src/pages/drills/components/RecentDrillRow.tsx
@@ -1,5 +1,5 @@
 import { Chessboard } from 'react-chessboard';
-import { formatDistanceToNow, parseISO } from 'date-fns';
+import { format, formatDistanceToNow, parseISO } from 'date-fns';
 import { Play } from 'lucide-react';
 
 import type { DrillPosition } from '@/types';
@@ -27,11 +27,33 @@ export default function RecentDrillRow({ drill, onPlay }: Props) {
       : 'text-red-500'
     : 'text-gray-400';
 
-  const dateStr = drill.last_drilled_at
-    ? formatDistanceToNow(parseISO(drill.last_drilled_at), {
-        addSuffix: true,
-      }).replace(/^about\s*/, '')
+  const heroColor =
+    drill.hero_result === 'win'
+      ? 'bg-green-500'
+      : drill.hero_result === 'loss'
+        ? 'bg-red-600'
+        : 'bg-gray-600';
+  const heroLabel =
+    drill.hero_result === 'win'
+      ? 'Win'
+      : drill.hero_result === 'loss'
+        ? 'Loss'
+        : 'Draw';
+
+  const reason = drill.result_reason
+    ?.replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+
+  const drilledDate = drill.last_drilled_at
+    ? parseISO(drill.last_drilled_at)
+    : null;
+  const dateStr = drilledDate
+    ? formatDistanceToNow(drilledDate, { addSuffix: true }).replace(
+        /^about\s*/,
+        ''
+      )
     : '';
+  const absolute = drilledDate ? format(drilledDate, 'yyyy-MM-dd HH:mm') : '';
 
   return (
     <li className="flex items-center gap-3 rounded-lg bg-gray-800 p-3">
@@ -51,10 +73,22 @@ export default function RecentDrillRow({ drill, onPlay }: Props) {
           </span>
           <span className={resultColor}>{resultLabel}</span>
         </div>
-        {drill.mastered && (
-          <span className="text-xs font-semibold text-green-500">Mastered</span>
+        <div className="flex justify-between text-xs text-gray-400">
+          <span className="flex items-center gap-1">
+            <span className={`rounded px-1 py-0.5 text-white ${heroColor}`}>
+              {heroLabel}
+            </span>
+            {reason && <span>{reason}</span>}
+          </span>
+          {drill.mastered && (
+            <span className="font-semibold text-green-500">Mastered</span>
+          )}
+        </div>
+        {dateStr && (
+          <time className="text-xs" dateTime={absolute}>
+            {dateStr}
+          </time>
         )}
-        {dateStr && <span className="text-xs text-gray-400">{dateStr}</span>}
       </div>
       <button
         onClick={() => onPlay(drill.id)}

--- a/src/pages/drills/components/RecentDrillRow.tsx
+++ b/src/pages/drills/components/RecentDrillRow.tsx
@@ -1,0 +1,68 @@
+import { Chessboard } from 'react-chessboard';
+import { formatDistanceToNow, parseISO } from 'date-fns';
+import { Play } from 'lucide-react';
+
+import type { DrillPosition } from '@/types';
+
+interface Props {
+  drill: DrillPosition;
+  onPlay: (id: number) => void;
+}
+
+export default function RecentDrillRow({ drill, onPlay }: Props) {
+  const orientation = drill.ply % 2 === 1 ? 'black' : 'white';
+
+  const last = [...drill.history].sort(
+    (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+  )[0];
+
+  const resultLabel = last
+    ? last.result === 'pass'
+      ? 'Passed'
+      : 'Failed'
+    : '-';
+  const resultColor = last
+    ? last.result === 'pass'
+      ? 'text-green-400'
+      : 'text-red-500'
+    : 'text-gray-400';
+
+  const dateStr = drill.last_drilled_at
+    ? formatDistanceToNow(parseISO(drill.last_drilled_at), {
+        addSuffix: true,
+      }).replace(/^about\s*/, '')
+    : '';
+
+  return (
+    <li className="flex items-center gap-3 rounded-lg bg-gray-800 p-3">
+      <Chessboard
+        position={drill.fen}
+        boardOrientation={orientation}
+        arePiecesDraggable={false}
+        boardWidth={120}
+        customBoardStyle={{ borderRadius: '0.5rem' }}
+        customDarkSquareStyle={{ backgroundColor: '#B1B7C8' }}
+        customLightSquareStyle={{ backgroundColor: '#F5F2E6' }}
+      />
+      <div className="flex flex-1 flex-col space-y-0.5 overflow-hidden">
+        <div className="flex justify-between text-sm">
+          <span className="truncate font-semibold">
+            vs {drill.opponent_username} ({drill.opponent_rating})
+          </span>
+          <span className={resultColor}>{resultLabel}</span>
+        </div>
+        {drill.mastered && (
+          <span className="text-xs font-semibold text-green-500">Mastered</span>
+        )}
+        {dateStr && <span className="text-xs text-gray-400">{dateStr}</span>}
+      </div>
+      <button
+        onClick={() => onPlay(drill.id)}
+        className="ml-2 inline-flex items-center gap-1 rounded bg-green-600 px-2 py-1 text-sm text-white hover:bg-green-700"
+      >
+        <Play size={14} />
+        Drill
+      </button>
+    </li>
+  );
+}

--- a/src/pages/drills/components/RecentDrillRow.tsx
+++ b/src/pages/drills/components/RecentDrillRow.tsx
@@ -1,52 +1,39 @@
 import { Chessboard } from 'react-chessboard';
 import { Play } from 'lucide-react';
 
+import { GameInfoBadges } from './DrillCard/GameInfoBadges';
 import { HistoryDots } from './DrillCard/HistoryDots';
-import { TimePhaseHeader } from './DrillCard/TimePhaseHeader';
 
-import { PHASE_COLORS, PHASE_DISPLAY } from '@/constants/phase';
-import type { DrillPosition } from '@/types';
-
-interface Props {
-  drill: DrillPosition;
-  onPlay: (id: number | string) => void;
-}
-
-export default function RecentDrillRow({ drill, onPlay }: Props) {
-  const {
-    fen,
-    ply,
-    game_played_at,
-    phase: apiPhase,
-    hero_result,
-    result_reason,
-    mastered,
-    history,
-  } = drill;
-
-  const orientation = ply % 2 === 1 ? 'black' : 'white';
-  const displayPhase = PHASE_DISPLAY[apiPhase] ?? 'Unknown';
-  const phaseColor = PHASE_COLORS[displayPhase] ?? 'bg-gray-700';
-
-  const resultLabel =
-    hero_result === 'win' ? 'Win' : hero_result === 'loss' ? 'Loss' : 'Draw';
-  const resultColor =
-    hero_result === 'win'
-      ? 'bg-green-500'
-      : hero_result === 'loss'
-        ? 'bg-red-600'
-        : 'bg-gray-600';
-
-  const reason = result_reason
-    ?.replace(/_/g, ' ')
-    .replace(/\b\w/g, (c) => c.toUpperCase());
-
-  return (
-    <li className="grid grid-cols-[120px_1fr_auto] items-center gap-3 rounded-lg bg-gray-800 p-3 text-white">
-      {/* Board */}
-      <div>
+      <div className="shrink-0">
         <Chessboard
-          position={fen}
+          position={drill.fen}
+          boardOrientation={orientation}
+          arePiecesDraggable={false}
+          boardWidth={120}
+          customBoardStyle={{ borderRadius: '0.5rem' }}
+          customDarkSquareStyle={{ backgroundColor: '#B1B7C8' }}
+          customLightSquareStyle={{ backgroundColor: '#F5F2E6' }}
+        />
+      </div>
+      <div className="flex flex-1 flex-col gap-1 overflow-hidden">
+        <div className="flex items-baseline justify-between">
+          <span className={`text-sm font-semibold ${resultColor}`}>
+            {resultLabel}
+          {dateStr && (
+            <time className="text-xs text-gray-400" dateTime={absolute}>
+              {dateStr}
+            </time>
+        <GameInfoBadges
+          timeClass={drill.time_class}
+          timeControl={drill.time_control}
+          opponent={{
+            username: drill.opponent_username,
+            rating: drill.opponent_rating,
+          }}
+          evalSwing={drill.eval_swing}
+          heroResult={drill.hero_result}
+        />
+        <HistoryDots history={drill.history} />
           boardOrientation={orientation}
           arePiecesDraggable={false}
           boardWidth={120}

--- a/src/pages/drills/hooks/useRecentDrills.ts
+++ b/src/pages/drills/hooks/useRecentDrills.ts
@@ -1,0 +1,28 @@
+import { useMemo } from 'react';
+import useSWR from 'swr';
+
+import { getRecentDrills } from '@/api/drills';
+
+export function useRecentDrills(
+  username: string,
+  opts: { limit?: number; includeArchived?: boolean } = {}
+) {
+  const { limit = 20, includeArchived = false } = opts;
+  const swrKey = useMemo(
+    () =>
+      username ? ['recentDrills', username, limit, includeArchived] : null,
+    [username, limit, includeArchived]
+  );
+
+  const { data, error, isValidating, mutate } = useSWR(swrKey, () =>
+    getRecentDrills({ username, limit, includeArchived })
+  );
+
+  return {
+    drills: data ?? [],
+    loading: !data && !error,
+    refreshing: isValidating,
+    error,
+    reload: mutate,
+  };
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -9,6 +9,7 @@ import Training from '@/pages/_placeholders/Training';
 import AnalyseGame from '@/pages/analyse';
 import Drills from '@/pages/drills';
 import PlayDrill from '@/pages/drills/components/PlayDrill';
+import RecentDrillsPage from '@/pages/drills/RecentDrillsPage';
 import GameHistory from '@/pages/games';
 import PreSignupHome from '@/pages/home/PreSignupHome';
 import NotFound from '@/pages/NotFound';
@@ -63,6 +64,14 @@ export default function AppRoutes() {
         element={
           <ProtectedRoute>
             <Drills />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/drills/recent"
+        element={
+          <ProtectedRoute>
+            <RecentDrillsPage />
           </ProtectedRoute>
         }
       />

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -133,6 +133,8 @@ export interface DrillPosition {
   opponent_rating: number;
   game_played_at: string;
   phase: 'opening' | 'middle' | 'late' | 'endgame';
+  mastered: boolean;
+  last_drilled_at?: string | null;
   archived: boolean;
   history: DrillHistory[];
 }


### PR DESCRIPTION
## Summary
- extend `DrillPosition` type with recent fields
- add API helper and hook for `/drills/recent`
- build `RecentDrillsPage` for showing last played drills
- wire page into sidebar navigation and routes

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68417a224018832ab732fedfd9fb6a14