### PR TITLE
Refactor Drills tab layout

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import { Drawer } from 'flowbite-react';
 import { motion } from 'framer-motion';
-import { Clock } from 'lucide-react';
 
 import EasterEggCredits, { useRapidTaps } from './EasterEggCredits';
 
@@ -97,12 +96,6 @@ export default function Sidebar({ isSidebarOpen, closeSidebar }) {
     ),
   };
 
-  const recentDrillsNav = {
-    to: '/drills/recent',
-    label: 'Recent Drills',
-    Icon: Clock,
-  };
-
   const bottomNav = [
     {
       to: '/help',
@@ -182,13 +175,6 @@ export default function Sidebar({ isSidebarOpen, closeSidebar }) {
               to={drillsNav.to}
               label={drillsNav.label}
               Icon={drillsNav.Icon}
-            />
-          </li>
-          <li>
-            <LinkItem
-              to={recentDrillsNav.to}
-              label={recentDrillsNav.label}
-              Icon={recentDrillsNav.Icon}
             />
           </li>
         </ul>

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface TabsProps {
+  labels: string[];
+  activeIndex: number;
+  onChange: (index: number) => void;
+  className?: string;
+}
+
+export default function Tabs({
+  labels,
+  activeIndex,
+  onChange,
+  className = '',
+}: TabsProps) {
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const [underlineStyle, setUnderlineStyle] = useState({ left: 0, width: 0 });
+
+  useEffect(() => {
+    const current = tabRefs.current[activeIndex];
+    if (current) {
+      setUnderlineStyle({
+        left: current.offsetLeft,
+        width: current.offsetWidth,
+      });
+    }
+  }, [activeIndex]);
+
+  return (
+    <div
+      className={`relative border-b border-gray-700 text-sm text-gray-400 ${className}`.trim()}
+    >
+      <div className="flex space-x-8">
+        {labels.map((label, idx) => (
+          <button
+            key={label}
+            ref={(el) => {
+              tabRefs.current[idx] = el;
+            }}
+            onClick={() => onChange(idx)}
+            className={`pb-3 tracking-wide transition-colors ${
+              activeIndex === idx ? 'text-white' : 'hover:text-gray-300'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+      <span
+        className="absolute bottom-0 block h-0.5 bg-blue-500 transition-all duration-300"
+        style={underlineStyle}
+      />
+    </div>
+  );
+}

--- a/src/hooks/useBreakpoint.ts
+++ b/src/hooks/useBreakpoint.ts
@@ -1,0 +1,42 @@
+export const BREAKPOINT_ORDER = ['xs', 'sm', 'md', 'lg', 'xl', '2xl'] as const;
+export type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | null;
+
+// src/util/useBreakpoint.ts
+import { useEffect, useMemo, useState } from 'react';
+
+import { isBrowser, off, on } from '@/lib/misc';
+
+type Breakpoints = Record<string, number>;
+
+export const breakpoints: Breakpoints = {
+  xs: 480, // 30rem
+  sm: 640, // Tailwind default
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+  '2xl': 1536,
+};
+
+export default function useBreakpoint() {
+  const [width, setWidth] = useState(isBrowser ? window.innerWidth : 0);
+
+  useEffect(() => {
+    const onResize = () => setWidth(window.innerWidth);
+    on(window, 'resize', onResize);
+    return () => off(window, 'resize', onResize);
+  }, []);
+
+  const current = useMemo(() => {
+    const sorted = Object.entries(breakpoints).sort(([, a], [, b]) => a - b);
+    for (let i = sorted.length - 1; i >= 0; i--) {
+      const [name, min] = sorted[i];
+      if (width >= min) return name as Breakpoint;
+    }
+    return null; // < smallest breakpoint
+  }, [width]);
+
+  const isAtLeast = (min: Breakpoint) =>
+    BREAKPOINT_ORDER.indexOf(current) >= BREAKPOINT_ORDER.indexOf(min);
+
+  return { current, isAtLeast, screenWidth: width };
+}

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -1,0 +1,27 @@
+export const noop = () => {};
+
+export function on<T extends EventTarget>(
+  obj: T | null,
+  type: string,
+  listener: (e: Event) => void,
+  options?: boolean | AddEventListenerOptions
+): void {
+  if (obj && obj.addEventListener) {
+    obj.addEventListener(type, listener, options);
+  }
+}
+
+export function off<T extends EventTarget>(
+  obj: T | null,
+  type: string,
+  listener: (e: Event) => void,
+  options?: boolean | EventListenerOptions
+): void {
+  if (obj && obj.removeEventListener) {
+    obj.removeEventListener(type, listener, options);
+  }
+}
+
+export const isBrowser = typeof window !== 'undefined';
+
+export const isNavigator = typeof navigator !== 'undefined';

--- a/src/pages/drills/components/DrillCard/index.tsx
+++ b/src/pages/drills/components/DrillCard/index.tsx
@@ -9,6 +9,7 @@ import { HistoryDots } from './HistoryDots';
 import { TimePhaseHeader } from './TimePhaseHeader';
 
 import { PHASE_COLORS, PHASE_DISPLAY } from '@/constants/phase';
+import useBreakpoint from '@/hooks/useBreakpoint';
 import type { DrillPosition } from '@/types';
 
 type Props = {
@@ -38,20 +39,33 @@ export function DrillCard({ drill, onStartDrill }: Props) {
   const displayPhase = PHASE_DISPLAY[apiPhase] ?? 'Unknown';
   const phaseColor = PHASE_COLORS[displayPhase] ?? 'bg-gray-700';
 
+  const { current, isAtLeast, screenWidth } = useBreakpoint();
+
+  const boardWidth = isAtLeast('sm')
+    ? 360
+    : current === 'xs'
+      ? 240
+      : screenWidth - 32;
+
+  console.debug('[useBreakpoint] ', current);
+
   return (
     <div
       className="xs:grid-cols-[240px_1fr] xs:gap-0 grid rounded-lg bg-gray-800 shadow sm:grid-cols-[360px_1fr]"
       onClick={() => onStartDrill(drill.id)}
     >
       {/* 1) Board */}
-      <Chessboard
-        position={fen}
-        boardOrientation={orientation}
-        arePiecesDraggable={false}
-        customBoardStyle={{ borderRadius: '0.5rem' }}
-        customDarkSquareStyle={{ backgroundColor: '#B1B7C8' }}
-        customLightSquareStyle={{ backgroundColor: '#F5F2E6' }}
-      />
+      <div className="shrink-0">
+        <Chessboard
+          position={fen}
+          boardOrientation={orientation}
+          arePiecesDraggable={false}
+          boardWidth={boardWidth}
+          customBoardStyle={{ borderRadius: '0.5rem' }}
+          customDarkSquareStyle={{ backgroundColor: '#B1B7C8' }}
+          customLightSquareStyle={{ backgroundColor: '#F5F2E6' }}
+        />
+      </div>
 
       {/* 2) Details */}
       <div className="flex flex-col justify-between rounded px-4 py-6 tracking-wide">

--- a/src/pages/drills/index.tsx
+++ b/src/pages/drills/index.tsx
@@ -163,7 +163,7 @@ export default function DrillsPage() {
             <span className="text-xs font-bold text-gray-500">lg</span>
           </div>
         </div>
-        <div className="mt-10 flex items-center justify-between">
+        <div className="mt-10 mb-4 flex items-center justify-between">
           <div className="text-sm text-gray-400 sm:text-base">
             {`Showing ${drills.length} result${drills.length === 1 ? '' : 's'}`}
           </div>

--- a/src/pages/drills/index.tsx
+++ b/src/pages/drills/index.tsx
@@ -1,6 +1,6 @@
 // src/pages/DrillsPage.tsx
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import RangeSlider from 'react-range-slider-input';
 import { useNavigate } from 'react-router-dom';
 import { Badge, TextInput } from 'flowbite-react';
@@ -107,6 +107,116 @@ export default function DrillsPage() {
 
   const { drills, loading, refresh } = useDrills(filters);
 
+  const newDrillsPanel = useMemo(
+    () => (
+      <>
+        {/* Controls */}
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          {/* Phase badges */}
+          <div className="flex flex-wrap items-center gap-2 text-gray-300">
+            {PHASES.map((p) => (
+              <Badge
+                key={p}
+                onClick={() => setPhaseFilter(p)}
+                className={`cursor-pointer rounded border-1 border-gray-800 px-2.5 py-2 text-xs capitalize ${
+                  phaseFilter === p && PHASE_COLORS[p]
+                }`}
+              >
+                {p}
+              </Badge>
+            ))}
+          </div>
+          {/* Refresh */}
+          <button
+            onClick={refresh}
+            disabled={loading}
+            className="xs:inline-flex hidden items-center rounded-full bg-gray-800 px-3 py-1 text-xs text-gray-300 hover:bg-gray-700 disabled:opacity-50"
+          >
+            <RefreshCw className="h-4 w-4" />
+            <span className="xs:block ml-2 hidden">Refresh</span>
+          </button>
+        </div>
+        <div className="mt-2 flex flex-wrap items-center justify-between gap-4">
+          {/* Search */}
+          <TextInput
+            placeholder="Search opponent"
+            value={search}
+            onChange={(e) => setSearch(e.currentTarget.value)}
+            className="min-w-40 flex-1"
+          />
+
+          {/* Discrete slider: left = hardest, right = All */}
+          <div className="flex items-baseline space-x-2 py-2">
+            <span className="mr-4 text-sm font-medium text-gray-300">
+              Blunder Size
+            </span>
+            <span className="text-xs font-bold text-gray-500">xs</span>
+            <div className="w-50">
+              <RangeSlider
+                min={0}
+                max={THRESHOLD_OPTIONS.length - 1}
+                step={1}
+                value={rangeIdx}
+                onInput={(vals) => setRangeIdx(vals as [number, number])}
+              />
+            </div>
+            <span className="text-xs font-bold text-gray-500">lg</span>
+          </div>
+        </div>
+        <div className="mt-10 flex items-center justify-between">
+          <div className="text-sm text-gray-400 sm:text-base">
+            {`Showing ${drills.length} result${drills.length === 1 ? '' : 's'}`}
+          </div>
+          <button
+            onClick={() => setShowFilters(true)}
+            className="flex items-center gap-2 text-sm text-gray-400 hover:text-white"
+          >
+            <SlidersHorizontal className="h-4 w-4" />
+            Filters
+          </button>
+        </div>
+        <FilterModal
+          show={showFilters}
+          onClose={() => setShowFilters(false)}
+          excludeWins={excludeWins}
+          setExcludeWins={setExcludeWins}
+          includeArchived={includeArchived}
+          setIncludeArchived={setIncludeArchived}
+          includeMastered={includeMastered}
+          setIncludeMastered={setIncludeMastered}
+          ToggleSwitch={ToggleSwitch}
+        />
+        {/* List */}
+        <DrillList
+          drills={drills}
+          loading={loading}
+          onStartDrill={(id) => navigate(`/drills/play/${id}`)}
+        />
+      </>
+    ),
+    [
+      drills,
+      loading,
+      phaseFilter,
+      excludeWins,
+      includeArchived,
+      includeMastered,
+      rangeIdx,
+      search,
+    ]
+  );
+
+  const historyPanel = useMemo(
+    () => (
+      <RecentDrillList
+        drills={recentDrills}
+        loading={recentLoading}
+        onPlay={(id) => navigate(`/drills/play/${id}`)}
+      />
+    ),
+    [recentDrills, recentLoading]
+  );
+
   return (
     <div className="p-4 pt-8 2xl:ml-12">
       <div className="mx-auto max-w-2xl space-y-4">
@@ -116,99 +226,8 @@ export default function DrillsPage() {
           onChange={setTabIndex}
           className="mb-12"
         />
-        {tabIndex === 0 && (
-          <>
-            {/* Controls */}
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              {/* Phase badges */}
-              <div className="flex flex-wrap items-center gap-2 text-gray-300">
-                {PHASES.map((p) => (
-                  <Badge
-                    key={p}
-                    onClick={() => setPhaseFilter(p)}
-                    className={`cursor-pointer rounded border-1 border-gray-800 px-2.5 py-2 text-xs capitalize ${
-                      phaseFilter === p && PHASE_COLORS[p]
-                    }`}
-                  >
-                    {p}
-                  </Badge>
-                ))}
-              </div>
-              {/* Refresh */}
-              <button
-                onClick={refresh}
-                disabled={loading}
-                className="xs:inline-flex hidden items-center rounded-full bg-gray-800 px-3 py-1 text-xs text-gray-300 hover:bg-gray-700 disabled:opacity-50"
-              >
-                <RefreshCw className="h-4 w-4" />
-                <span className="xs:block ml-2 hidden">Refresh</span>
-              </button>
-            </div>
-            <div className="mt-2 flex flex-wrap items-center justify-between gap-4">
-              {/* Search */}
-              <TextInput
-                placeholder="Search opponent"
-                value={search}
-                onChange={(e) => setSearch(e.currentTarget.value)}
-                className="min-w-40 flex-1"
-              />
-
-              {/* Discrete slider: left = hardest, right = All */}
-              <div className="flex items-baseline space-x-2 py-2">
-                <span className="mr-4 text-sm font-medium text-gray-300">
-                  Blunder Size
-                </span>
-                <span className="text-xs font-bold text-gray-500">xs</span>
-                <div className="w-50">
-                  <RangeSlider
-                    min={0}
-                    max={THRESHOLD_OPTIONS.length - 1}
-                    step={1}
-                    value={rangeIdx}
-                    onInput={(vals) => setRangeIdx(vals as [number, number])}
-                  />
-                </div>
-                <span className="text-xs font-bold text-gray-500">lg</span>
-              </div>
-            </div>
-            <div className="mt-10 flex items-center justify-between">
-              <div className="text-sm text-gray-400 sm:text-base">
-                {`Showing ${drills.length} result${drills.length === 1 ? '' : 's'}`}
-              </div>
-              <button
-                onClick={() => setShowFilters(true)}
-                className="flex items-center gap-2 text-sm text-gray-400 hover:text-white"
-              >
-                <SlidersHorizontal className="h-4 w-4" />
-                Filters
-              </button>
-            </div>
-            <FilterModal
-              show={showFilters}
-              onClose={() => setShowFilters(false)}
-              excludeWins={excludeWins}
-              setExcludeWins={setExcludeWins}
-              includeArchived={includeArchived}
-              setIncludeArchived={setIncludeArchived}
-              includeMastered={includeMastered}
-              setIncludeMastered={setIncludeMastered}
-              ToggleSwitch={ToggleSwitch}
-            />
-            {/* List */}
-            <DrillList
-              drills={drills}
-              loading={loading}
-              onStartDrill={(id) => navigate(`/drills/play/${id}`)}
-            />
-          </>
-        )}
-        {tabIndex === 1 && (
-          <RecentDrillList
-            drills={recentDrills}
-            loading={recentLoading}
-            onPlay={(id) => navigate(`/drills/play/${id}`)}
-          />
-        )}
+        <div className={tabIndex === 0 ? '' : 'hidden'}>{newDrillsPanel}</div>
+        <div className={tabIndex === 1 ? '' : 'hidden'}>{historyPanel}</div>
       </div>
     </div>
   );

--- a/src/pages/drills/index.tsx
+++ b/src/pages/drills/index.tsx
@@ -226,8 +226,8 @@ export default function DrillsPage() {
           onChange={setTabIndex}
           className="mb-12"
         />
-        {tabIndex === 0 && newDrillsPanel}
-        {tabIndex === 1 && historyPanel}
+        <div className={tabIndex === 0 ? '' : 'hidden'}>{newDrillsPanel}</div>
+        <div className={tabIndex === 1 ? '' : 'hidden'}>{historyPanel}</div>
       </div>
     </div>
   );

--- a/src/pages/drills/index.tsx
+++ b/src/pages/drills/index.tsx
@@ -226,8 +226,8 @@ export default function DrillsPage() {
           onChange={setTabIndex}
           className="mb-12"
         />
-        <div className={tabIndex === 0 ? '' : 'hidden'}>{newDrillsPanel}</div>
-        <div className={tabIndex === 1 ? '' : 'hidden'}>{historyPanel}</div>
+        {tabIndex === 0 && newDrillsPanel}
+        {tabIndex === 1 && historyPanel}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- turn `/drills` into tabbed home for new and historical drills
- move TabGroup to a reusable `Tabs` component
- drop the `Recent Drills` sidebar entry

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68427eb7fa1c832ab5d7c25d932e26bc