### PR TITLE
Add Mastered drills tab

### DIFF
--- a/src/api/drills.ts
+++ b/src/api/drills.ts
@@ -77,6 +77,27 @@ export async function getRecentDrills({
   return res.json() as Promise<DrillPosition[]>;
 }
 
+export interface MasteredDrillOpts {
+  username: string;
+  limit?: number;
+  includeArchived?: boolean;
+}
+
+export async function getMasteredDrills({
+  username,
+  limit = 20,
+  includeArchived = false,
+}: MasteredDrillOpts) {
+  const params = new URLSearchParams({ username, limit: String(limit) });
+  if (includeArchived) params.append('include_archived', 'true');
+
+  const res = await fetch(`${BASE_URL}/drills/mastered?${params.toString()}`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch mastered drills: ${res.status}`);
+  }
+  return res.json() as Promise<DrillPosition[]>;
+}
+
 // Fetch single drill by ID
 export async function getDrill(id: number) {
   const res = await fetch(`${BASE_URL}/drills/${id}`);

--- a/src/pages/drills/hooks/useMasteredDrills.ts
+++ b/src/pages/drills/hooks/useMasteredDrills.ts
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+import useSWR from 'swr';
+
+import { getMasteredDrills } from '@/api/drills';
+
+export function useMasteredDrills(
+  username: string,
+  opts: { limit?: number; includeArchived?: boolean } = {}
+) {
+  const { limit = 20, includeArchived = false } = opts;
+  const swrKey = useMemo(
+    () => (username ? ['masteredDrills', username, limit, includeArchived] : null),
+    [username, limit, includeArchived]
+  );
+
+  const { data, error, isValidating, mutate } = useSWR(swrKey, () =>
+    getMasteredDrills({ username, limit, includeArchived })
+  );
+
+  return {
+    drills: data ?? [],
+    loading: !data && !error,
+    refreshing: isValidating,
+    error,
+    reload: mutate,
+  };
+}

--- a/src/pages/drills/index.tsx
+++ b/src/pages/drills/index.tsx
@@ -11,6 +11,7 @@ import FilterModal from './components/FilterModal';
 import RecentDrillList from './components/RecentDrillList';
 import { useDrills } from './hooks/useDrills';
 import { useRecentDrills } from './hooks/useRecentDrills';
+import { useMasteredDrills } from './hooks/useMasteredDrills';
 import {
   buildDrillFilters,
   PhaseFilter,
@@ -61,6 +62,8 @@ export default function DrillsPage() {
 
   const { drills: recentDrills, loading: recentLoading } =
     useRecentDrills(username);
+  const { drills: masteredDrills, loading: masteredLoading } =
+    useMasteredDrills(username);
 
   // UI state
   const [phaseFilter, setPhaseFilter] = useStickyValue<Phase>(
@@ -225,6 +228,17 @@ export default function DrillsPage() {
     [recentDrills, recentLoading]
   );
 
+  const masteredPanel = useMemo(
+    () => (
+      <RecentDrillList
+        drills={masteredDrills}
+        loading={masteredLoading}
+        onPlay={(id) => navigate(`/drills/play/${id}`)}
+      />
+    ),
+    [masteredDrills, masteredLoading]
+  );
+
   return (
     <div className="p-4 pt-8 2xl:ml-12">
       <div className="mx-auto max-w-2xl space-y-4">
@@ -236,8 +250,9 @@ export default function DrillsPage() {
         />
         <div className={tabIndex === 0 ? '' : 'hidden'}>{newDrillsPanel}</div>
         <div className={tabIndex === 1 ? '' : 'hidden'}>{historyPanel}</div>
+        <div className={tabIndex === 2 ? '' : 'hidden'}>{masteredPanel}</div>
       </div>
     </div>
   );
 }
-const TABS = ['New Drills', 'History'];
+const TABS = ['New Drills', 'History', 'Mastered'];


### PR DESCRIPTION
## Summary
- expose mastered drills API call
- add hook for mastered drills
- add Mastered tab and panel on drills page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f0ecf5f0832aa25b0eb5367a5383