### PR TITLE
Add customizable background setting

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>BlunderFixer</title>
   </head>
   <body class="relative z-0 bg-stone-50 antialiased dark:bg-stone-900">
-    <!-- Background image layer -->
+    <!-- Example background layers for development -->
     <!-- <div
       class="pointer-events-none absolute inset-0 z-5 bg-[url('/blunderfixer_tiled_bg.png')] bg-[length:700px] bg-repeat opacity-[2%]"
       aria-hidden="true"
@@ -16,10 +16,10 @@
       class="pointer-events-none absolute inset-0 z-5 bg-[url('/blunderfixer_bg_chess.png')] bg-[length:900px] bg-repeat opacity-[3%]"
       aria-hidden="true"
     ></div> -->
-    <div
+    <!-- <div
       class="pointer-events-none absolute inset-0 z-5 bg-[url('/blunderfixer_bg_questionmarks.png')] bg-[length:900px] bg-repeat opacity-[3%]"
       aria-hidden="true"
-    ></div>
+    ></div> -->
 
     <!-- Main app content -->
     <div id="root" class="relative z-10 flex w-full"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,11 @@
+// src/App.jsx
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
+import BackgroundLayer from './components/BackgroundLayer';
 import Navbar from './components/Navbar';
 import Sidebar from './components/Sidebar';
 import AppRoutes from './routes';
-import BackgroundLayer from './components/BackgroundLayer';
 
 import { useProfile } from '@/hooks/useProfile';
 
@@ -35,7 +36,9 @@ export default function App() {
       <BackgroundLayer />
       <Navbar toggleSidebar={toggleSidebar} />
       <Sidebar isSidebarOpen={isSidebarOpen} closeSidebar={closeSidebar} />
-      <main className={`min-h-screen w-full ${loggedIn && 'pt-8 2xl:pl-32'}`}>
+      <main
+        className={`z-10 min-h-screen w-full ${loggedIn && 'pt-8 2xl:pl-32'}`}
+      >
         <AppRoutes />
       </main>
     </>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import { useLocation } from 'react-router-dom';
 import Navbar from './components/Navbar';
 import Sidebar from './components/Sidebar';
 import AppRoutes from './routes';
+import BackgroundLayer from './components/BackgroundLayer';
 
 import { useProfile } from '@/hooks/useProfile';
 
@@ -31,6 +32,7 @@ export default function App() {
 
   return (
     <>
+      <BackgroundLayer />
       <Navbar toggleSidebar={toggleSidebar} />
       <Sidebar isSidebarOpen={isSidebarOpen} closeSidebar={closeSidebar} />
       <main className={`min-h-screen w-full ${loggedIn && 'pt-8 2xl:pl-32'}`}>

--- a/src/components/BackgroundLayer.tsx
+++ b/src/components/BackgroundLayer.tsx
@@ -1,15 +1,24 @@
 // src/components/BackgroundLayer.tsx
-import { PATTERN_OPTIONS, BackgroundPattern } from '@/constants/background';
-import { useStickyValue } from '@/hooks/useStickyValue';
+import { PATTERN_OPTIONS } from '@/constants/background';
+import { useBackgroundPattern } from '@/hooks/useBackgroundPattern';
 
 export default function BackgroundLayer() {
-  const [pattern] = useStickyValue<BackgroundPattern>('backgroundPattern', 'off');
+  const { pattern } = useBackgroundPattern();
   const option = PATTERN_OPTIONS.find((o) => o.value === pattern);
-  if (!option || !option.class) return null;
+
+  console.log('BackgroundLayer', option);
+  if (!option || !option.bgImage) return null;
   return (
     <div
-      className={`pointer-events-none fixed inset-0 z-0 ${option.class}`}
+      className={[
+        'pointer-events-none fixed inset-0 z-0 h-screen w-screen bg-repeat',
+        option.sizeClass,
+        option.opacityClass,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      style={{ backgroundImage: `url(${option.bgImage})` }}
       aria-hidden="true"
-    ></div>
+    />
   );
 }

--- a/src/components/BackgroundLayer.tsx
+++ b/src/components/BackgroundLayer.tsx
@@ -1,0 +1,15 @@
+// src/components/BackgroundLayer.tsx
+import { PATTERN_OPTIONS, BackgroundPattern } from '@/constants/background';
+import { useStickyValue } from '@/hooks/useStickyValue';
+
+export default function BackgroundLayer() {
+  const [pattern] = useStickyValue<BackgroundPattern>('backgroundPattern', 'off');
+  const option = PATTERN_OPTIONS.find((o) => o.value === pattern);
+  if (!option || !option.class) return null;
+  return (
+    <div
+      className={`pointer-events-none fixed inset-0 z-0 ${option.class}`}
+      aria-hidden="true"
+    ></div>
+  );
+}

--- a/src/components/UsernameInput.tsx
+++ b/src/components/UsernameInput.tsx
@@ -2,6 +2,7 @@
 interface Props {
   username: string;
   onUsernameChange: (u: string) => void;
+  id: string;
 }
 
 export default function UsernameInput({ username, onUsernameChange }: Props) {

--- a/src/constants/background.ts
+++ b/src/constants/background.ts
@@ -1,8 +1,32 @@
 export type BackgroundPattern = 'chess' | 'questions' | 'classic' | 'off';
 
-export const PATTERN_OPTIONS: { value: BackgroundPattern; label: string; class: string }[] = [
-  { value: 'chess', label: "Queen's Gambit", class: "bg-[url('/blunderfixer_bg_chess.png')] bg-[length:900px] bg-repeat opacity-[3%]" },
-  { value: 'questions', label: 'Why so serious?', class: "bg-[url('/blunderfixer_bg_questionmarks.png')] bg-[length:900px] bg-repeat opacity-[3%]" },
-  { value: 'classic', label: 'BlunderFixer Classic', class: "bg-[url('/blunderfixer_tiled_bg.png')] bg-[length:700px] bg-repeat opacity-[2%]" },
-  { value: 'off', label: 'Off (Blank Slate)', class: '' },
+export const PATTERN_OPTIONS: {
+  value: BackgroundPattern;
+  label: string;
+  bgImage?: string; // <- just the image path
+  sizeClass?: string;
+  opacityClass?: string;
+}[] = [
+  {
+    value: 'chess',
+    label: "Queen's Gambit",
+    bgImage: '/blunderfixer_bg_chess.png',
+    sizeClass: 'bg-[length:900px]',
+    opacityClass: 'opacity-[4%]',
+  },
+  {
+    value: 'questions',
+    label: 'BlunderFixer Classic',
+    bgImage: '/blunderfixer_bg_questionmarks.png',
+    sizeClass: 'bg-[length:900px]',
+    opacityClass: 'opacity-[3%]',
+  },
+  {
+    value: 'classic',
+    label: 'Why so serious?',
+    bgImage: '/blunderfixer_tiled_bg.png',
+    sizeClass: 'bg-[length:700px]',
+    opacityClass: 'opacity-[2%]',
+  },
+  { value: 'off', label: 'Blank Slate (None)' },
 ];

--- a/src/constants/background.ts
+++ b/src/constants/background.ts
@@ -1,0 +1,8 @@
+export type BackgroundPattern = 'chess' | 'questions' | 'classic' | 'off';
+
+export const PATTERN_OPTIONS: { value: BackgroundPattern; label: string; class: string }[] = [
+  { value: 'chess', label: "Queen's Gambit", class: "bg-[url('/blunderfixer_bg_chess.png')] bg-[length:900px] bg-repeat opacity-[3%]" },
+  { value: 'questions', label: 'Why so serious?', class: "bg-[url('/blunderfixer_bg_questionmarks.png')] bg-[length:900px] bg-repeat opacity-[3%]" },
+  { value: 'classic', label: 'BlunderFixer Classic', class: "bg-[url('/blunderfixer_tiled_bg.png')] bg-[length:700px] bg-repeat opacity-[2%]" },
+  { value: 'off', label: 'Off (Blank Slate)', class: '' },
+];

--- a/src/contexts/BackgroundPatternContext.ts
+++ b/src/contexts/BackgroundPatternContext.ts
@@ -1,0 +1,8 @@
+import { createContext } from 'react';
+
+import { BackgroundPattern } from '@/constants/background';
+
+export const BackgroundPatternContext = createContext<{
+  pattern: BackgroundPattern;
+  setPattern: (val: BackgroundPattern) => void;
+} | null>(null);

--- a/src/contexts/BackgroundPatternProvider.tsx
+++ b/src/contexts/BackgroundPatternProvider.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react';
+
+import { BackgroundPatternContext } from './BackgroundPatternContext';
+
+import { BackgroundPattern } from '@/constants/background';
+
+const PREFIX = 'bf:params:backgroundPattern';
+
+export function BackgroundPatternProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [pattern, setPatternState] = useState<BackgroundPattern>('off');
+
+  useEffect(() => {
+    const stored = localStorage.getItem(PREFIX);
+    if (stored) setPatternState(JSON.parse(stored));
+  }, []);
+
+  const setPattern = (val: BackgroundPattern) => {
+    setPatternState(val);
+    localStorage.setItem(PREFIX, JSON.stringify(val));
+  };
+
+  return (
+    <BackgroundPatternContext.Provider value={{ pattern, setPattern }}>
+      {children}
+    </BackgroundPatternContext.Provider>
+  );
+}

--- a/src/hooks/useBackgroundPattern.ts
+++ b/src/hooks/useBackgroundPattern.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+
+import { BackgroundPatternContext } from '@/contexts/BackgroundPatternContext';
+
+export function useBackgroundPattern() {
+  const ctx = useContext(BackgroundPatternContext);
+  if (!ctx)
+    throw new Error(
+      'useBackgroundPattern must be used within a BackgroundPatternProvider'
+    );
+  return ctx;
+}

--- a/src/hooks/useStickyValue.ts
+++ b/src/hooks/useStickyValue.ts
@@ -1,22 +1,25 @@
-// src/hooks/useStickyValue.ts
-
 import { useEffect, useState } from 'react';
 
 const PREFIX = 'bf:params:';
 
 export function useStickyValue<T>(
   key: string,
-  defaultValue: T
-): [T, (v: T | ((prev: T) => T)) => void] {
+  defaultValue?: T
+): [T | undefined, (v: T | ((prev: T | undefined) => T)) => void] {
   const storageKey = `${PREFIX}${key}`;
 
-  const [value, setValue] = useState<T>(() => {
+  const [value, setValue] = useState<T | undefined>(() => {
     const stickyValue = localStorage.getItem(storageKey);
-    return stickyValue !== null ? JSON.parse(stickyValue) : defaultValue;
+    if (stickyValue !== null) {
+      return JSON.parse(stickyValue);
+    }
+    return defaultValue;
   });
 
   useEffect(() => {
-    localStorage.setItem(storageKey, JSON.stringify(value));
+    if (value !== undefined) {
+      localStorage.setItem(storageKey, JSON.stringify(value));
+    }
   }, [storageKey, value]);
 
   return [value, setValue];

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -8,6 +8,7 @@ import DevErrorBoundary from './components/DevErrorBoundary.jsx';
 import './index.css';
 
 import 'flowbite';
+import { BackgroundPatternProvider } from '@/contexts/BackgroundPatternProvider';
 import { ProfileProvider } from '@/hooks/useProfile';
 
 const drawerTheme = createTheme({
@@ -23,9 +24,11 @@ createRoot(document.getElementById('root')).render(
     <BrowserRouter>
       <DevErrorBoundary>
         <ProfileProvider>
-          <ThemeProvider theme={drawerTheme}>
-            <App />
-          </ThemeProvider>
+          <BackgroundPatternProvider>
+            <ThemeProvider theme={drawerTheme}>
+              <App />
+            </ThemeProvider>
+          </BackgroundPatternProvider>
         </ProfileProvider>
       </DevErrorBoundary>
     </BrowserRouter>

--- a/src/pages/settings/index.jsx
+++ b/src/pages/settings/index.jsx
@@ -7,12 +7,15 @@ import { Gem, MapPin, Table, Users } from 'lucide-react';
 import UsernameInput from '@/components/UsernameInput';
 import { useDebounce } from '@/hooks/useDebounce';
 import { useProfile } from '@/hooks/useProfile';
+import { useStickyValue } from '@/hooks/useStickyValue';
+import { PATTERN_OPTIONS, BackgroundPattern } from '@/constants/background';
 
 export default function Settings() {
   const { profile, setUsername } = useProfile();
   const navigate = useNavigate();
   // Local input state
   const [localUsername, setLocalUsername] = useState(profile.username);
+  const [bgPattern, setBgPattern] = useStickyValue<BackgroundPattern>('backgroundPattern', 'off');
 
   // Whenever the real profile username changes (e.g. on load or outside),
   // keep the input in sync
@@ -143,6 +146,25 @@ export default function Settings() {
         <p className="mt-1 text-xs text-stone-500">
           Enter a new handle to refresh your profile data.
         </p>
+
+        <label
+          htmlFor="bgPattern"
+          className="mb-1 mt-6 block text-sm font-medium text-stone-200"
+        >
+          Background Pattern
+        </label>
+        <select
+          id="bgPattern"
+          value={bgPattern}
+          onChange={(e) => setBgPattern(e.target.value as BackgroundPattern)}
+          className="w-full rounded border border-stone-600 bg-stone-800 px-2 py-1 text-white"
+        >
+          {PATTERN_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
       </div>
     </div>
   );

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -5,17 +5,18 @@ import { formatDistanceToNow } from 'date-fns';
 import { Gem, MapPin, Table, Users } from 'lucide-react';
 
 import UsernameInput from '@/components/UsernameInput';
+import { BackgroundPattern, PATTERN_OPTIONS } from '@/constants/background';
+import { useBackgroundPattern } from '@/hooks/useBackgroundPattern';
 import { useDebounce } from '@/hooks/useDebounce';
 import { useProfile } from '@/hooks/useProfile';
-import { useStickyValue } from '@/hooks/useStickyValue';
-import { PATTERN_OPTIONS, BackgroundPattern } from '@/constants/background';
 
 export default function Settings() {
   const { profile, setUsername } = useProfile();
   const navigate = useNavigate();
   // Local input state
   const [localUsername, setLocalUsername] = useState(profile.username);
-  const [bgPattern, setBgPattern] = useStickyValue<BackgroundPattern>('backgroundPattern', 'off');
+  const { pattern: bgPattern, setPattern: setBgPattern } =
+    useBackgroundPattern();
 
   // Whenever the real profile username changes (e.g. on load or outside),
   // keep the input in sync
@@ -43,7 +44,7 @@ export default function Settings() {
     : '';
 
   return (
-    <div className="flex min-h-screen items-start justify-center bg-stone-900 p-4 sm:p-6">
+    <div className="flex min-h-screen items-start justify-center p-4 sm:p-6">
       <div className="absolute top-16 left-4 md:hidden">
         <button
           onClick={() => navigate(-1)}
@@ -149,7 +150,7 @@ export default function Settings() {
 
         <label
           htmlFor="bgPattern"
-          className="mb-1 mt-6 block text-sm font-medium text-stone-200"
+          className="mt-6 mb-1 block text-sm font-medium text-stone-200"
         >
           Background Pattern
         </label>


### PR DESCRIPTION
## Summary
- allow selecting app background
- render chosen pattern in a new `BackgroundLayer`
- add selection UI to Settings
- keep examples in `index.html` commented

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684407dc8c40832a8f1b5e0007b5716e