### PR TITLE
Implement time format preferences

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 - Prioritised
 
-  [ ] FEAT: Detect which formats (Biltz, Rapid, Bullet, Daily) I care about when I log in (allow me to change in preferences) (consider using ToggleSwitch). Only show EloDisplay options for chosen preferences.
+  [x] FEAT: Detect which formats (Biltz, Rapid, Bullet, Daily) I care about when I log in (allow me to change in preferences) (consider using ToggleSwitch). Only show EloDisplay options for chosen preferences.
   [ ] FEAT: Wire up stats on home screen
 
 - Backlog

--- a/src/components/EloDisplay.tsx
+++ b/src/components/EloDisplay.tsx
@@ -3,6 +3,7 @@ import { CalendarClock, TimerReset } from 'lucide-react';
 
 import blitzIcon from '@/assets/blitz.png';
 import bulletIcon from '@/assets/bullet.png';
+import { TIME_ORDER } from '@/const/phase';
 import { type TimeClass, useChessComRatings } from '@/hooks/useChessComRatings';
 
 const icons: Record<TimeClass, JSX.Element> = {
@@ -20,18 +21,22 @@ export default function EloDisplay() {
   const { rating, delta, timeClass, setTimeClass, preferred } =
     useChessComRatings();
 
+  const sortedPreferred = [...preferred].sort(
+    (a, b) => TIME_ORDER.indexOf(a) - TIME_ORDER.indexOf(b)
+  );
+
   const touchStartX = useRef<number | null>(null);
   const lastTrigger = useRef(0);
   const cooldown = 700; // ms
 
   const cycleTimeClass = (dir: 'left' | 'right') => {
-    const index = preferred.indexOf(timeClass);
+    const index = sortedPreferred.indexOf(timeClass);
     if (index === -1) return;
     const nextIndex =
       dir === 'left'
-        ? (index + 1) % preferred.length
-        : (index - 1 + preferred.length) % preferred.length;
-    setTimeClass(preferred[nextIndex]);
+        ? (index - 1) % sortedPreferred.length
+        : (index + 1 + sortedPreferred.length) % sortedPreferred.length;
+    setTimeClass(sortedPreferred[nextIndex]);
   };
 
   return (
@@ -77,7 +82,7 @@ export default function EloDisplay() {
       </div>
       {preferred.length > 1 && (
         <div className="flex space-x-2">
-          {preferred.map((tc) => (
+          {sortedPreferred.map((tc) => (
             <button
               key={tc}
               onClick={() => setTimeClass(tc)}

--- a/src/components/EloDisplay.tsx
+++ b/src/components/EloDisplay.tsx
@@ -1,4 +1,4 @@
-import { TimerReset } from 'lucide-react';
+import { CalendarClock, TimerReset } from 'lucide-react';
 import type { JSX } from 'react';
 
 import blitzIcon from '@/assets/blitz.png';
@@ -13,10 +13,11 @@ const icons: Record<TimeClass, JSX.Element> = {
     <img src={blitzIcon} alt="blitz" className="inline h-6 bg-transparent" />
   ),
   rapid: <TimerReset className="mb-1 inline h-5 bg-transparent" />,
+  daily: <CalendarClock className="mb-1 inline h-5 bg-transparent" />,
 };
 
 export default function EloDisplay() {
-  const { rating, delta, timeClass, setTimeClass } = useChessComRatings();
+  const { rating, delta, timeClass, setTimeClass, preferred } = useChessComRatings();
 
   return (
     <div className="mt-4 flex items-center justify-between rounded bg-stone-800 px-4 py-3">
@@ -37,22 +38,24 @@ export default function EloDisplay() {
           )}
         </div>
       </div>
-      <div className="flex space-x-2">
-        {(['bullet', 'blitz', 'rapid'] as TimeClass[]).map((tc) => (
-          <button
-            key={tc}
-            onClick={() => setTimeClass(tc)}
-            className={`rounded p-1 ${
-              tc === timeClass
-                ? 'bg-stone-700 text-white'
-                : 'text-white opacity-50'
-            }`}
-            title={tc.charAt(0).toUpperCase() + tc.slice(1)}
-          >
-            {icons[tc]}
-          </button>
-        ))}
-      </div>
+      {preferred.length > 1 && (
+        <div className="flex space-x-2">
+          {preferred.map((tc) => (
+            <button
+              key={tc}
+              onClick={() => setTimeClass(tc)}
+              className={`rounded p-1 ${
+                tc === timeClass
+                  ? 'bg-stone-700 text-white'
+                  : 'text-white opacity-50'
+              }`}
+              title={tc.charAt(0).toUpperCase() + tc.slice(1)}
+            >
+              {icons[tc]}
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/const/phase.ts
+++ b/src/const/phase.ts
@@ -1,4 +1,6 @@
 // src/constants/phase.ts
+import { type TimeClass } from '@/hooks/useChessComRatings';
+
 export const PHASE_DISPLAY: Record<string, string> = {
   opening: 'Opening',
   middle: 'Middle',
@@ -11,3 +13,4 @@ export const PHASE_COLORS: Record<string, string> = {
   Late: 'bg-fuchsia-700',
   Endgame: 'bg-rose-700',
 };
+export const TIME_ORDER: TimeClass[] = ['bullet', 'blitz', 'rapid', 'daily'];

--- a/src/hooks/useChessComRatings.ts
+++ b/src/hooks/useChessComRatings.ts
@@ -2,12 +2,17 @@ import { useEffect, useState } from 'react';
 
 import { useProfile } from './useProfile';
 
-export type TimeClass = 'bullet' | 'blitz' | 'rapid';
+export type TimeClass = 'bullet' | 'blitz' | 'rapid' | 'daily';
+
+function isTimeClass(val: any): val is TimeClass {
+  return val === 'bullet' || val === 'blitz' || val === 'rapid' || val === 'daily';
+}
 
 interface Ratings {
   bullet?: number;
   blitz?: number;
   rapid?: number;
+  daily?: number;
 }
 
 interface UseChessComRatings {
@@ -16,6 +21,8 @@ interface UseChessComRatings {
   timeClass: TimeClass;
   setTimeClass: (tc: TimeClass) => void;
   ratings: Ratings;
+  preferred: TimeClass[];
+  setPreferred: (val: TimeClass[]) => void;
 }
 
 export function useChessComRatings(): UseChessComRatings {
@@ -26,16 +33,22 @@ export function useChessComRatings(): UseChessComRatings {
   const [ratings, setRatings] = useState<Ratings>({});
   const [previous, setPrevious] = useState<Ratings>({});
   const [timeClass, setTimeClassState] = useState<TimeClass>('blitz');
+  const [preferred, setPreferredState] = useState<TimeClass[]>([]);
 
-  // load stored previous ratings and preferred time class
+  // load stored previous ratings and preferred time class & list
   useEffect(() => {
     if (!username) return;
     try {
       const prevRaw = localStorage.getItem(`bf:elo_prev:${username}`);
       if (prevRaw) setPrevious(JSON.parse(prevRaw));
       const pref = localStorage.getItem(`bf:elo_pref:${username}`) as TimeClass;
-      if (pref === 'bullet' || pref === 'blitz' || pref === 'rapid') {
+      if (isTimeClass(pref)) {
         setTimeClassState(pref);
+      }
+      const listRaw = localStorage.getItem(`bf:elo_formats:${username}`);
+      if (listRaw) {
+        const arr = JSON.parse(listRaw);
+        if (Array.isArray(arr)) setPreferredState(arr.filter(isTimeClass));
       }
     } catch {
       // ignore
@@ -51,6 +64,7 @@ export function useChessComRatings(): UseChessComRatings {
         const bullet = data.chess_bullet?.last?.rating;
         const blitz = data.chess_blitz?.last?.rating;
         const rapid = data.chess_rapid?.last?.rating;
+        const daily = data.chess_daily?.last?.rating;
 
         const bulletGames =
           (data.chess_bullet?.record?.win ?? 0) +
@@ -64,8 +78,12 @@ export function useChessComRatings(): UseChessComRatings {
           (data.chess_rapid?.record?.win ?? 0) +
           (data.chess_rapid?.record?.loss ?? 0) +
           (data.chess_rapid?.record?.draw ?? 0);
+        const dailyGames =
+          (data.chess_daily?.record?.win ?? 0) +
+          (data.chess_daily?.record?.loss ?? 0) +
+          (data.chess_daily?.record?.draw ?? 0);
 
-        setRatings({ bullet, blitz, rapid });
+        setRatings({ bullet, blitz, rapid, daily });
 
         // default preferred time class based on most games
         const prefKey = `bf:elo_pref:${username}`;
@@ -74,16 +92,30 @@ export function useChessComRatings(): UseChessComRatings {
             ['bullet', bulletGames],
             ['blitz', blitzGames],
             ['rapid', rapidGames],
+            ['daily', dailyGames],
           ];
           counts.sort((a, b) => b[1] - a[1]);
           setTimeClassState(counts[0][0]);
           localStorage.setItem(prefKey, counts[0][0]);
         }
 
+        const listKey = `bf:elo_formats:${username}`;
+        if (!localStorage.getItem(listKey)) {
+          const detected: TimeClass[] = [];
+          if (bulletGames > 0) detected.push('bullet');
+          if (blitzGames > 0) detected.push('blitz');
+          if (rapidGames > 0) detected.push('rapid');
+          if (dailyGames > 0) detected.push('daily');
+          const defaults = detected.length ? detected : ['blitz'];
+          setPreferredState(defaults);
+          localStorage.setItem(listKey, JSON.stringify(defaults));
+          if (!defaults.includes(timeClass)) setTimeClassState(defaults[0]);
+        }
+
         // store current as new previous for next login
         localStorage.setItem(
           `bf:elo_prev:${username}`,
-          JSON.stringify({ bullet, blitz, rapid })
+          JSON.stringify({ bullet, blitz, rapid, daily })
         );
       })
       .catch(() => {
@@ -104,5 +136,14 @@ export function useChessComRatings(): UseChessComRatings {
     }
   };
 
-  return { rating, delta, timeClass, setTimeClass, ratings };
+  const setPreferred = (vals: TimeClass[]) => {
+    if (!vals.length) return;
+    setPreferredState(vals);
+    if (username) {
+      localStorage.setItem(`bf:elo_formats:${username}`, JSON.stringify(vals));
+    }
+    setTimeClassState((prev) => (vals.includes(prev) ? prev : vals[0]));
+  };
+
+  return { rating, delta, timeClass, setTimeClass, ratings, preferred, setPreferred };
 }

--- a/src/pages/drills/components/PlayDrill.tsx
+++ b/src/pages/drills/components/PlayDrill.tsx
@@ -210,11 +210,11 @@ export default function PlayDrill() {
     <>
       <div className="mx-auto max-w-md space-y-4">
         <a
-          onClick={() => navigate('/drills')}
-          aria-label="Back to list"
+          onClick={() => navigate(-1)}
+          aria-label="Back"
           className="xs:ml-0 relative top-4 z-100 ml-4 inline-flex w-fit items-center py-1 pr-4 text-blue-600 hover:underline"
         >
-          ← Back to list
+          ← Back
         </a>
         {/* ---------- Board + EvalBar ---------- */}
         <div className="mt-4 flex flex-col items-center">

--- a/src/pages/insights/index.tsx
+++ b/src/pages/insights/index.tsx
@@ -372,7 +372,7 @@ export default function HomeScreen() {
 
           {/* Recent Games */}
           <div className="mt-12 mb-2 flex justify-between">
-            <h2 className="text-2xl font-semibold text-stone-100">
+            <h2 className="text-xl font-semibold text-stone-100">
               Recent Games
             </h2>
             <button

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -4,13 +4,13 @@ import { useNavigate } from 'react-router-dom';
 import { formatDistanceToNow } from 'date-fns';
 import { Gem, MapPin, Table, Users } from 'lucide-react';
 
-import UsernameInput from '@/components/UsernameInput';
 import ToggleSwitch from '@/components/ToggleSwitch';
+import UsernameInput from '@/components/UsernameInput';
 import { BackgroundPattern, PATTERN_OPTIONS } from '@/const/background';
 import { useBackgroundPattern } from '@/hooks/useBackgroundPattern';
+import { type TimeClass, useChessComRatings } from '@/hooks/useChessComRatings';
 import { useDebounce } from '@/hooks/useDebounce';
 import { useProfile } from '@/hooks/useProfile';
-import { useChessComRatings, type TimeClass } from '@/hooks/useChessComRatings';
 
 export default function Settings() {
   const { profile, setUsername } = useProfile();
@@ -171,9 +171,9 @@ export default function Settings() {
         </select>
 
         <label className="mt-6 mb-1 block text-sm font-medium text-stone-200">
-          Show Ratings For
+          Enable Ratings / Stats
         </label>
-        <div className="space-y-2">
+        <div className="space-x-6">
           {(['bullet', 'blitz', 'rapid', 'daily'] as TimeClass[]).map((tc) => (
             <ToggleSwitch
               key={tc}

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -5,10 +5,12 @@ import { formatDistanceToNow } from 'date-fns';
 import { Gem, MapPin, Table, Users } from 'lucide-react';
 
 import UsernameInput from '@/components/UsernameInput';
+import ToggleSwitch from '@/components/ToggleSwitch';
 import { BackgroundPattern, PATTERN_OPTIONS } from '@/const/background';
 import { useBackgroundPattern } from '@/hooks/useBackgroundPattern';
 import { useDebounce } from '@/hooks/useDebounce';
 import { useProfile } from '@/hooks/useProfile';
+import { useChessComRatings, type TimeClass } from '@/hooks/useChessComRatings';
 
 export default function Settings() {
   const { profile, setUsername } = useProfile();
@@ -17,6 +19,7 @@ export default function Settings() {
   const [localUsername, setLocalUsername] = useState(profile.username);
   const { pattern: bgPattern, setPattern: setBgPattern } =
     useBackgroundPattern();
+  const { preferred, setPreferred } = useChessComRatings();
 
   // Whenever the real profile username changes (e.g. on load or outside),
   // keep the input in sync
@@ -166,6 +169,26 @@ export default function Settings() {
             </option>
           ))}
         </select>
+
+        <label className="mt-6 mb-1 block text-sm font-medium text-stone-200">
+          Show Ratings For
+        </label>
+        <div className="space-y-2">
+          {(['bullet', 'blitz', 'rapid', 'daily'] as TimeClass[]).map((tc) => (
+            <ToggleSwitch
+              key={tc}
+              checked={preferred.includes(tc)}
+              onChange={() =>
+                setPreferred(
+                  preferred.includes(tc)
+                    ? preferred.filter((p) => p !== tc)
+                    : [...preferred, tc]
+                )
+              }
+              label={tc.charAt(0).toUpperCase() + tc.slice(1)}
+            />
+          ))}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- expand Elo rating hooks to handle bullet, blitz, rapid & daily
- detect preferred time controls based on Chess.com stats
- persist selected rating formats per user
- only show selectable formats on the Elo display
- allow editing rating formats in Settings
- tick off completed TODO entry

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6845ed1d0330832a8ea3702b607a69a3