### PR TITLE
Improve insights dashboard UI

### DIFF
--- a/src/components/EloDisplay.tsx
+++ b/src/components/EloDisplay.tsx
@@ -63,12 +63,12 @@ export default function EloDisplay() {
         touchStartX.current = null;
       }}
     >
-      <div className="relative flex flex-col">
+      <div className="relative flex flex-col" title="Chess.com rating">
         <div className="flex items-baseline space-x-2 text-white">
           <span className="text-2xl font-bold">
             {rating !== null ? rating : '--'}
           </span>
-          <span className="text-sm font-medium">Elo</span>
+          <span className="text-sm font-medium">Chess.com Elo</span>
 
           {delta !== null && (
             <span
@@ -92,6 +92,7 @@ export default function EloDisplay() {
                   : 'text-white opacity-50'
               }`}
               title={tc.charAt(0).toUpperCase() + tc.slice(1)}
+              aria-label={tc}
             >
               {icons[tc]}
             </button>

--- a/src/pages/insights/components/AdvancedStats.tsx
+++ b/src/pages/insights/components/AdvancedStats.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { ChevronDown } from 'lucide-react';
+import { BarChart2, ChevronDown } from 'lucide-react';
 import {
   Bar,
   BarChart,
@@ -32,9 +32,10 @@ export default function AdvancedStats() {
     <>
       <div className="mb-6 flex justify-start">
         <button
-          className="flex items-center text-sm text-blue-400 hover:underline"
+          className="flex items-center text-base font-semibold text-blue-400 hover:underline"
           onClick={() => setShowCharts((v) => !v)}
         >
+          <BarChart2 className="mr-1 h-4 w-4" />
           {showCharts ? 'Hide Stats' : 'More Stats'}
           <ChevronDown
             className={`ml-1 h-4 w-4 transition-transform ${showCharts ? 'rotate-180' : ''}`}
@@ -53,7 +54,12 @@ export default function AdvancedStats() {
                   <PolarGrid stroke="#444" />
                   <PolarAngleAxis dataKey="eco" stroke="#888" />
                   <PolarRadiusAxis stroke="#888" />
-                  <Radar dataKey="score" stroke="#60a5fa" fill="#60a5fa" fillOpacity={0.6} />
+                  <Radar
+                    dataKey="score"
+                    stroke="#60a5fa"
+                    fill="#60a5fa"
+                    fillOpacity={0.6}
+                  />
                   <Tooltip />
                 </RadarChart>
               </ResponsiveContainer>
@@ -70,17 +76,27 @@ export default function AdvancedStats() {
                   <XAxis dataKey="phase" stroke="#888" />
                   <YAxis stroke="#888" />
                   <Tooltip />
-                  <Line type="monotone" dataKey="acpl" stroke="#a78bfa" strokeWidth={2} />
+                  <Line
+                    type="monotone"
+                    dataKey="acpl"
+                    stroke="#a78bfa"
+                    strokeWidth={2}
+                  />
                 </LineChart>
               </ResponsiveContainer>
             </div>
           </div>
 
           <div>
-            <h2 className="mb-4 text-xl font-semibold text-stone-100">Reason for Loss</h2>
+            <h2 className="mb-4 text-xl font-semibold text-stone-100">
+              Reason for Loss
+            </h2>
             <div className="h-60 w-full">
               <ResponsiveContainer width="100%" height="100%">
-                <BarChart data={lossReasonsData} margin={{ left: -20, right: 20 }}>
+                <BarChart
+                  data={lossReasonsData}
+                  margin={{ left: -20, right: 20 }}
+                >
                   <CartesianGrid stroke="#444" />
                   <XAxis dataKey="reason" stroke="#888" />
                   <YAxis stroke="#888" />
@@ -92,10 +108,15 @@ export default function AdvancedStats() {
           </div>
 
           <div>
-            <h2 className="mb-4 text-xl font-semibold text-stone-100">Impulsive vs Slow</h2>
+            <h2 className="mb-4 text-xl font-semibold text-stone-100">
+              Impulsive vs Slow
+            </h2>
             <div className="h-60 w-full">
               <ResponsiveContainer width="100%" height="100%">
-                <BarChart data={timeControlData} margin={{ left: -20, right: 20 }}>
+                <BarChart
+                  data={timeControlData}
+                  margin={{ left: -20, right: 20 }}
+                >
                   <CartesianGrid stroke="#444" />
                   <XAxis dataKey="control" stroke="#888" />
                   <YAxis stroke="#888" />

--- a/src/pages/insights/components/DrillSection.tsx
+++ b/src/pages/insights/components/DrillSection.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import { Target } from 'lucide-react';
 
 import NextDrillCarousel from './NextDrillCarousel';
+
 import type { DrillPosition } from '@/types';
 
 interface Props {
@@ -16,7 +17,8 @@ export default function DrillSection({ drills, loading }: Props) {
     <section className="mt-12">
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-xl font-semibold text-stone-100">
-          <Target className="relative bottom-0.25 mr-1 inline-flex w-5" /> More Drills
+          <Target className="relative bottom-0.25 mr-1 inline-flex w-5" /> More
+          Drills
         </h2>
         <button
           className="text-sm text-blue-400 hover:underline"
@@ -25,10 +27,14 @@ export default function DrillSection({ drills, loading }: Props) {
           All Drills »
         </button>
       </div>
+      <p className="mb-4 text-sm text-stone-400">Based on recent mistakes</p>
       {loading ? (
         <p className="mt-4 text-center text-stone-500">Loading…</p>
       ) : (
-        <NextDrillCarousel drills={drills} onStart={(id) => navigate(`/drills/play/${id}`)} />
+        <NextDrillCarousel
+          drills={drills}
+          onStart={(id) => navigate(`/drills/play/${id}`)}
+        />
       )}
     </section>
   );

--- a/src/pages/insights/components/GameSection.tsx
+++ b/src/pages/insights/components/GameSection.tsx
@@ -10,7 +10,12 @@ interface Props {
   onAnalyse: (game: GameRecord) => void;
 }
 
-export default function GameSection({ games, username, loading, onAnalyse }: Props) {
+export default function GameSection({
+  games,
+  username,
+  loading,
+  onAnalyse,
+}: Props) {
   const navigate = useNavigate();
 
   return (

--- a/src/pages/insights/components/HeroSection.tsx
+++ b/src/pages/insights/components/HeroSection.tsx
@@ -9,7 +9,11 @@ interface Props {
   greeting: string;
 }
 
-export default function HeroSection({ username, nextDrillId, greeting }: Props) {
+export default function HeroSection({
+  username,
+  nextDrillId,
+  greeting,
+}: Props) {
   const navigate = useNavigate();
 
   return (
@@ -17,15 +21,16 @@ export default function HeroSection({ username, nextDrillId, greeting }: Props) 
       <h1 className="text-3xl font-bold text-stone-100">
         Welcome back{username ? `, ${username}` : ''}!
       </h1>
-      <p className="leading-snug text-stone-400">{greeting}</p>
-      <div className="mt-8 flex justify-start">
+      <p className="mt-1 text-sm leading-snug text-stone-400">{greeting}</p>
+      <div className="mt-6 flex justify-start">
         <button
           onClick={() =>
             navigate(nextDrillId ? `/drills/play/${nextDrillId}` : '/drills')
           }
           className="rounded bg-green-600 px-4 py-2 text-sm font-semibold text-white hover:bg-green-700"
         >
-          Next Drill <Play className="relative bottom-0.25 ml-1 inline h-4 w-4" />
+          Next Drill{' '}
+          <Play className="relative bottom-0.25 ml-1 inline h-4 w-4" />
         </button>
       </div>
       <div className="mt-8">

--- a/src/pages/insights/components/StatCard.tsx
+++ b/src/pages/insights/components/StatCard.tsx
@@ -1,8 +1,11 @@
+import { TrendingDown, TrendingUp } from 'lucide-react';
+
 interface Props {
   value: string | number;
   label: string;
   desc: string;
   colorClass: string;
+  trend?: 'up' | 'down';
   className?: string;
 }
 
@@ -11,11 +14,27 @@ export default function StatCard({
   label,
   desc,
   colorClass,
+  trend,
   className = '',
 }: Props) {
   return (
-    <div className={`rounded bg-stone-800 p-4 text-center ${className}`}>
-      <p className={`text-2xl font-semibold ${colorClass}`}>{value}</p>
+    <div
+      className={`cursor-default rounded bg-stone-800 p-4 text-center select-none ${className}`}
+    >
+      <p
+        className={`flex items-center justify-center text-2xl font-semibold ${colorClass}`}
+      >
+        {value}
+        {trend && (
+          <span className="ml-1">
+            {trend === 'up' ? (
+              <TrendingUp className="inline h-4 w-4" />
+            ) : (
+              <TrendingDown className="inline h-4 w-4" />
+            )}
+          </span>
+        )}
+      </p>
       <p className="text-base text-stone-200 sm:text-sm">{label}</p>
       <p className="mt-1 text-xs text-stone-400">{desc}</p>
     </div>

--- a/src/pages/insights/components/StatsSummary.tsx
+++ b/src/pages/insights/components/StatsSummary.tsx
@@ -2,18 +2,28 @@ import StatCard from './StatCard';
 import WinRateDial from './WinRateDial';
 
 export default function StatsSummary() {
-  const stats = [
+  type Stat = {
+    value: string | number;
+    label: string;
+    desc: string;
+    color: string;
+    trend?: 'up' | 'down';
+  };
+
+  const stats: Stat[] = [
     {
       value: '123',
       label: 'Blunders Fixed',
       desc: 'Mistakes you corrected',
       color: 'text-blue-400',
+      trend: 'up',
     },
     {
       value: '64%',
       label: 'Tactic Accuracy',
       desc: 'Top-engine moves chosen',
       color: 'text-green-400',
+      trend: 'down',
     },
     {
       value: '75%',
@@ -40,6 +50,7 @@ export default function StatsSummary() {
               value={stat.value}
               label={stat.label}
               desc={stat.desc}
+              trend={stat.trend}
               colorClass={stat.color}
               className="min-w-[200px] shrink-0 snap-center"
             />
@@ -54,6 +65,7 @@ export default function StatsSummary() {
             value={stat.value}
             label={stat.label}
             desc={stat.desc}
+            trend={stat.trend}
             colorClass={stat.color}
           />
         ))}

--- a/src/pages/insights/index.tsx
+++ b/src/pages/insights/index.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react';
 
-import HeroSection from './components/HeroSection';
-import StatsSummary from './components/StatsSummary';
 import AdvancedStats from './components/AdvancedStats';
 import DrillSection from './components/DrillSection';
 import GameSection from './components/GameSection';
+import HeroSection from './components/HeroSection';
+import StatsSummary from './components/StatsSummary';
+
 import { greetings } from '@/const/greetings';
 import { useAnalyseAndGoToReport } from '@/hooks/useAnalyseAndGoToReport';
 import { useProfile } from '@/hooks/useProfile';
@@ -27,14 +28,14 @@ export default function HomeScreen() {
       includeMastered: false,
       rangeIdx: [0, 5],
     },
-    undefined,
+    undefined
   );
 
   const { drills, loading: loadingDrills } = useDrills(filters);
 
   const { games: rawGames, loading: loadingGames } = useRecentGames(
     username,
-    3,
+    3
   );
 
   const analyseAndGo = useAnalyseAndGoToReport();


### PR DESCRIPTION
## Summary
- tweak spacing and font in HeroSection
- clarify EloDisplay label and improve accessibility
- add trend arrows to StatCard and pass them through StatsSummary
- make stat cards non-interactive and show trend arrows
- enhance AdvancedStats toggle styling
- clarify drill carousel context
- lint fixes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68472483530c832a9103544e6695a896