### PR TITLE
Fix mobile nav not visible when at page top

### DIFF
--- a/src/components/MobileGlobalNav.tsx
+++ b/src/components/MobileGlobalNav.tsx
@@ -12,8 +12,6 @@ import {
   X,
 } from 'lucide-react';
 
-import EloDisplay from './EloDisplay';
-
 import blunderLogoSvg from '@/assets/blunderfixer.svg';
 import useBlundersFixed from '@/hooks/useBlundersFixed';
 import { useProfile } from '@/hooks/useProfile';
@@ -45,7 +43,7 @@ export default function MobileGlobalNav() {
     navigate(path);
   };
 
-  const scrollUp = useScrollDirection();
+  const scrollUp = useScrollDirection(100);
 
   return (
     <>

--- a/src/hooks/useScrollDirection.ts
+++ b/src/hooks/useScrollDirection.ts
@@ -1,18 +1,25 @@
 import { useEffect, useState } from 'react';
 
-export function useScrollDirection() {
+export function useScrollDirection(threshold = 50) {
   const [scrollUp, setScrollUp] = useState(true);
 
   useEffect(() => {
     let lastY = window.scrollY;
     const onScroll = () => {
       const currentY = window.scrollY;
-      setScrollUp(currentY < lastY);
+
+      if (currentY <= threshold) {
+        setScrollUp(true);
+      } else {
+        setScrollUp(currentY < lastY);
+      }
+
       lastY = currentY;
     };
+
     window.addEventListener('scroll', onScroll, { passive: true });
     return () => window.removeEventListener('scroll', onScroll);
-  }, []);
+  }, [threshold]);
 
   return scrollUp;
 }


### PR DESCRIPTION
## Summary
- adjust scroll detection hook to stay visible near top
- keep `MobileGlobalNav` visible until user scrolls past 100px

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684aa7a9d230832a853e36c7326cfa75