### PR TITLE
Add logo to mobile nav sheet

### DIFF
--- a/src/components/MobileGlobalNav.tsx
+++ b/src/components/MobileGlobalNav.tsx
@@ -12,11 +12,12 @@ import {
   X,
 } from 'lucide-react';
 
+import SignOutConfirmModal from './SignOutConfirmModal';
+
 //import EloDisplay from './EloDisplay';
 import blunderLogoSvg from '@/assets/blunderfixer.svg';
 import useBlundersFixed from '@/hooks/useBlundersFixed';
 import { useProfile } from '@/hooks/useProfile';
-import SignOutConfirmModal from './SignOutConfirmModal';
 import { useScrollDirection } from '@/hooks/useScrollDirection';
 
 export default function MobileGlobalNav() {
@@ -98,6 +99,13 @@ export default function MobileGlobalNav() {
             >
               {/* Drag handle */}
               <div className="mx-auto mb-4 h-1.5 w-10 rounded-full bg-stone-200" />
+
+              {/* Logo top-left */}
+              <img
+                src={blunderLogoSvg}
+                alt="BlunderFixer logo"
+                className="shake-icon absolute top-3 left-4 h-6 w-6"
+              />
 
               {/* Close button top-right */}
               <button

--- a/src/components/MobileGlobalNav.tsx
+++ b/src/components/MobileGlobalNav.tsx
@@ -55,6 +55,15 @@ export default function MobileGlobalNav() {
 
   const scrollUp = useScrollDirection();
 
+  // derive flag emoji
+  const countryCode = profile.country?.split('/').pop()?.toUpperCase() || '';
+  const flagEmoji = countryCode
+    ? countryCode
+        .split('')
+        .map((c) => String.fromCodePoint(c.charCodeAt(0) + 127397))
+        .join('')
+    : '';
+
   return (
     <>
       <motion.button
@@ -100,13 +109,6 @@ export default function MobileGlobalNav() {
               {/* Drag handle */}
               <div className="mx-auto mb-4 h-1.5 w-10 rounded-full bg-stone-200" />
 
-              {/* Logo top-left */}
-              <img
-                src={blunderLogoSvg}
-                alt="BlunderFixer logo"
-                className="shake-icon absolute top-3 left-4 h-6 w-6"
-              />
-
               {/* Close button top-right */}
               <button
                 className="absolute top-3 right-4 z-10 text-stone-200 hover:text-black"
@@ -127,6 +129,7 @@ export default function MobileGlobalNav() {
                 )}
                 <p className="mt-2 text-white">
                   {profile.name || profile.username}
+                  {flagEmoji && <span className="ml-1">{flagEmoji}</span>}
                 </p>
                 <p className="text-xs text-stone-400">@{profile.username}</p>
               </div>

--- a/src/components/SignOutConfirmModal.tsx
+++ b/src/components/SignOutConfirmModal.tsx
@@ -6,7 +6,11 @@ interface Props {
   onConfirm: () => void;
 }
 
-export default function SignOutConfirmModal({ show, onCancel, onConfirm }: Props) {
+export default function SignOutConfirmModal({
+  show,
+  onCancel,
+  onConfirm,
+}: Props) {
   return (
     <Modal show={show} onClose={onCancel}>
       <h2 className="mb-4 text-lg font-semibold text-white">Sign out?</h2>


### PR DESCRIPTION
## Summary
- show the BlunderFixer icon on the mobile global navigation card
- address ESLint style warning in `SignOutConfirmModal`

## Testing
- `npm run lint` *(fails: 1 error, 29 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684ab285904c832abd4768b9401089d3