### PR TITLE
Fix initial board position in report view

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,8 +2,6 @@
 
 - Prioritised
 
-  [x] [TODO_prod] Run alembic upgrade head to deploy move and eval migrations to drillhistory table
-  [x] FIX: When viewing a /report the board should show the first move in the table which if only critical moves is enabled it should show the first critical move not the first move
   [ ] FIX: Drills, Endgames – explain that we should play until the end, don't lose if the advantage drops and its still winning only end, only count as fail if it's now a dead draw
   [ ] FIX: Drills, For Endgames – in drill worker ignore drills where the blunders occur that were already in losing positions (unwinable) OR alternatively for those positons don't force play till the end? [DECISION]
 
@@ -23,6 +21,8 @@
 [ ] Opening Trainer (practice specific openings, where the computer will gladly enter into certain lines with you)
 [ ] Endgame Trainer (two rooks, extra pawn etc.)
 
+[x] [TODO_prod] Run alembic upgrade head to deploy move and eval migrations to drillhistory table
+[x] FIX: When viewing a /report the board should show the first move in the table which if only critical moves is enabled it should show the first critical move not the first move
 [x] Fix PGN paster so we can use analysis mode inside BlunderFixer
 [x] Copy PGN -> analyse position
 [x] Switch to analysis mode in a drill

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,8 @@
 
 - Prioritised
 
+  [x] [TODO_prod] Run alembic upgrade head to deploy move and eval migrations to drillhistory table
+  [x] FIX: When viewing a /report the board should show the first move in the table which if only critical moves is enabled it should show the first critical move not the first move
   [ ] FIX: Drills, Endgames – explain that we should play until the end, don't lose if the advantage drops and its still winning only end, only count as fail if it's now a dead draw
   [ ] FIX: Drills, For Endgames – in drill worker ignore drills where the blunders occur that were already in losing positions (unwinable) OR alternatively for those positons don't force play till the end? [DECISION]
 

--- a/src/hooks/useReportTableFilters.ts
+++ b/src/hooks/useReportTableFilters.ts
@@ -1,0 +1,17 @@
+import { useStickyValue } from './useStickyValue';
+
+export interface ReportTableFilters {
+  showAll: boolean;
+  setShowAll: (v: boolean | ((prev: boolean) => boolean)) => void;
+  heroOnly: boolean;
+  setHeroOnly: (v: boolean | ((prev: boolean) => boolean)) => void;
+}
+
+export function useReportTableFilters(): ReportTableFilters {
+  const [showAll, setShowAll] = useStickyValue<boolean>('showAllMoves', false);
+  const [heroOnly, setHeroOnly] = useStickyValue<boolean>(
+    'showHeroMovesOnly',
+    false
+  );
+  return { showAll, setShowAll, heroOnly, setHeroOnly };
+}

--- a/src/pages/report/components/GameSummary.tsx
+++ b/src/pages/report/components/GameSummary.tsx
@@ -1,13 +1,14 @@
-// src/pages/games/components/GameSummary.tsx
-import { useEffect, useMemo, useState } from 'react';
+// src/pages/report/components/GameSummary.tsx
+import { useMemo, useState } from 'react';
 
+import { useInitialSelectedIndex } from '../hooks/useInitialSelectedIndex';
+import { useReportTableFilters } from '../hooks/useReportTableFilters';
 import EvalGraph from './EvalGraph';
 import GameSummaryHeader from './GameSummaryHeader';
 import StackView from './StackView';
 import GameSummaryTable, { CombinedEntry } from './SummaryTable';
 import TimeUsageChart from './TimeUsageChart';
 
-import { useReportTableFilters } from '@/hooks/useReportTableFilters';
 import {
   getErrorSeverity,
   getTimeSeverity,
@@ -78,16 +79,14 @@ export function GameSummary({
   );
 
   // set initial position to first entry shown in the table
-  useEffect(() => {
-    if (selectedIndex != null || combined.length === 0) return;
-    const entry = combined.find(
-      (e) =>
-        (showAll || e.tags[0] !== 'none') &&
-        (!heroOnly || e.move.side === heroSide)
-    );
-    if (entry) setSelectedIndex(entry.analysis.halfMoveIndex);
-    else setSelectedIndex(combined[0].analysis.halfMoveIndex);
-  }, [combined, heroSide, selectedIndex, showAll, heroOnly]);
+  useInitialSelectedIndex({
+    combined,
+    selectedIndex,
+    setSelectedIndex,
+    heroSide,
+    showAll,
+    heroOnly,
+  });
 
   // 3) Time‐usage chart data
   const timeData: TimePoint[] = useMemo(() => {

--- a/src/pages/report/components/GameSummary.tsx
+++ b/src/pages/report/components/GameSummary.tsx
@@ -7,6 +7,7 @@ import StackView from './StackView';
 import GameSummaryTable, { CombinedEntry } from './SummaryTable';
 import TimeUsageChart from './TimeUsageChart';
 
+import { useReportTableFilters } from '@/hooks/useReportTableFilters';
 import {
   getErrorSeverity,
   getTimeSeverity,
@@ -33,6 +34,8 @@ export function GameSummary({
   const MAX = 4;
 
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const { showAll, setShowAll, heroOnly, setHeroOnly } =
+    useReportTableFilters();
 
   // 1) Eval‐graph data
   const chartData = useMemo(
@@ -77,20 +80,6 @@ export function GameSummary({
   // set initial position to first entry shown in the table
   useEffect(() => {
     if (selectedIndex != null || combined.length === 0) return;
-    let showAll = false;
-    try {
-      const raw = localStorage.getItem('bf:params:showAllMoves');
-      if (raw !== null) showAll = JSON.parse(raw);
-    } catch {
-      // ignore parse errors
-    }
-    let heroOnly = false;
-    try {
-      const raw = localStorage.getItem('bf:params:showHeroMovesOnly');
-      if (raw !== null) heroOnly = JSON.parse(raw);
-    } catch {
-      // ignore parse errors
-    }
     const entry = combined.find(
       (e) =>
         (showAll || e.tags[0] !== 'none') &&
@@ -98,7 +87,7 @@ export function GameSummary({
     );
     if (entry) setSelectedIndex(entry.analysis.halfMoveIndex);
     else setSelectedIndex(combined[0].analysis.halfMoveIndex);
-  }, [combined, heroSide, selectedIndex]);
+  }, [combined, heroSide, selectedIndex, showAll, heroOnly]);
 
   // 3) Time‐usage chart data
   const timeData: TimePoint[] = useMemo(() => {
@@ -152,6 +141,10 @@ export function GameSummary({
             pgn={game.pgn}
             timeControl={game.meta.timeControl}
             heroSide={heroSide}
+            showAll={showAll}
+            setShowAll={setShowAll}
+            heroOnly={heroOnly}
+            setHeroOnly={setHeroOnly}
           />
         </aside>
         {/* Right pane: board + transport */}

--- a/src/pages/report/components/StackView.tsx
+++ b/src/pages/report/components/StackView.tsx
@@ -13,7 +13,7 @@ export default function StackView({
   heroSide,
 }: {
   entries: CombinedEntry[];
-  onDrill?: (pgn: string, halfMoveIndex: number) => void;
+  onDrill?: (pgn: string, halfMoveIndex: number, heroSide: 'w' | 'b') => void;
   pgn: string;
   selectedIndex?: number | null;
   heroSide: 'w' | 'b';

--- a/src/pages/report/components/SummaryTable.tsx
+++ b/src/pages/report/components/SummaryTable.tsx
@@ -3,7 +3,6 @@ import { useMemo } from 'react';
 
 import TableView from './TableView';
 
-import { useStickyValue } from '@/hooks/useStickyValue';
 import type { Severity } from '@/lib/severity';
 import { DOT_COLOR, scoreMove } from '@/lib/severity';
 import type { AnalysisNode, GameRecord } from '@/types';
@@ -21,6 +20,10 @@ interface GameSummaryTableProps {
   pgn: string;
   timeControl?: number;
   heroSide: 'w' | 'b';
+  showAll: boolean;
+  setShowAll: (v: boolean | ((prev: boolean) => boolean)) => void;
+  heroOnly: boolean;
+  setHeroOnly: (v: boolean | ((prev: boolean) => boolean)) => void;
 }
 
 function ToggleSwitch({
@@ -70,12 +73,11 @@ export default function GameSummaryTable({
   onClick,
   timeControl,
   heroSide,
+  showAll,
+  setShowAll,
+  heroOnly,
+  setHeroOnly,
 }: GameSummaryTableProps) {
-  const [showAll, setShowAll] = useStickyValue<boolean>('showAllMoves', false);
-  const [heroOnly, setHeroOnly] = useStickyValue<boolean>(
-    'showHeroMovesOnly',
-    false
-  );
   // compute top-5 by score
   const keyEntries = useMemo(() => {
     return [...combined]

--- a/src/pages/report/hooks/useInitialSelectedIndex.ts
+++ b/src/pages/report/hooks/useInitialSelectedIndex.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+
+import type { CombinedEntry } from '../components/SummaryTable';
+
+export function useInitialSelectedIndex({
+  combined,
+  selectedIndex,
+  setSelectedIndex,
+  heroSide,
+  showAll,
+  heroOnly,
+}: {
+  combined: CombinedEntry[];
+  selectedIndex: number | null;
+  setSelectedIndex: (i: number) => void;
+  heroSide: 'w' | 'b';
+  showAll: boolean;
+  heroOnly: boolean;
+}) {
+  useEffect(() => {
+    if (selectedIndex != null || combined.length === 0) return;
+    const entry = combined.find(
+      (e) =>
+        (showAll || e.tags[0] !== 'none') &&
+        (!heroOnly || e.move.side === heroSide)
+    );
+    if (entry) setSelectedIndex(entry.analysis.halfMoveIndex);
+    else setSelectedIndex(combined[0].analysis.halfMoveIndex);
+  }, [combined, heroSide, selectedIndex, showAll, heroOnly]);
+}

--- a/src/pages/report/hooks/useReportTableFilters.ts
+++ b/src/pages/report/hooks/useReportTableFilters.ts
@@ -1,4 +1,4 @@
-import { useStickyValue } from './useStickyValue';
+import { useStickyValue } from '../../../hooks/useStickyValue';
 
 export interface ReportTableFilters {
   showAll: boolean;


### PR DESCRIPTION
## Summary
- ensure the report board opens on the first entry shown in the table
- include time control params in dependencies

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684acdacfd9c832aa8e5bd1d076e4646