### PR TITLE
Implement endgame rules in PlayDrill

### DIFF
--- a/src/pages/drills/components/DrillBanner.tsx
+++ b/src/pages/drills/components/DrillBanner.tsx
@@ -9,6 +9,7 @@ interface Props {
   setResetKey: React.Dispatch<React.SetStateAction<number>>;
   onNext: () => void;
   initialEval?: number;
+  isEndgame?: boolean;
 }
 
 function getRandomMessage(messages: string[]) {
@@ -22,6 +23,7 @@ export default function DrillBanner({
   setResetKey,
   onNext,
   initialEval,
+  isEndgame = false,
 }: Props) {
   const drawMessage = useMemo(
     () =>
@@ -87,6 +89,7 @@ export default function DrillBanner({
             <Crosshair className="relative bottom-0.25 mr-2 inline-flex h-4 w-4 text-purple-400" />
             <span className="text-sm">
               <span className="mr-1 font-bold text-white/80">
+                {isEndgame && 'Play until the end — '}
                 {expectedResult === 'win' &&
                   initialEval !== undefined &&
                   (initialEval >= 200 ? convertMessage : maintainMessage)}

--- a/src/pages/drills/components/PlayDrill.tsx
+++ b/src/pages/drills/components/PlayDrill.tsx
@@ -107,7 +107,11 @@ export default function PlayDrill() {
 
   // 9) Decide defaults for this drill:
   const initialEval = drill?.initial_eval ?? null;
-  const maxMoves = drill?.phase === 'endgame' ? 0 : REQUIRED_MOVES;
+  const isEndgame = drill?.phase === 'endgame';
+  const isLosingStart =
+    initialEval !== null &&
+    (heroColor === 'white' ? initialEval <= -100 : initialEval >= 100);
+  const maxMoves = isEndgame && !isLosingStart ? 0 : REQUIRED_MOVES;
   const lossThreshold = Math.max(drill?.initial_eval / 2, 100); // default to half the initial eval or 100 CP
 
   // 10) Drill‐result hook
@@ -231,6 +235,7 @@ export default function PlayDrill() {
             setResetKey={setResetKey}
             onNext={handleNextDrill}
             initialEval={initialEval}
+            isEndgame={isEndgame && !isLosingStart}
           />
           <div className="mt-4 flex w-full items-center">
             {/* <EvalBar


### PR DESCRIPTION
## Summary
- adjust DrillBanner to note endgame play and accept `isEndgame`
- pass `isEndgame` from PlayDrill
- refine useDrillResult logic for endgames
- treat already-losing endgames as normal drills

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684afee66420832a9cb2984bdf3d2e69