### PR TITLE
Fix duplicate drill history saving

### DIFF
--- a/src/pages/drills/components/hooks/useSaveDrillHistory.ts
+++ b/src/pages/drills/components/hooks/useSaveDrillHistory.ts
@@ -27,9 +27,16 @@ export function useSaveDrillHistory({
     profile: { username },
   } = useProfile();
 
+  // Reset posted flag when changing drills or when the result is cleared
+  useEffect(() => {
+    if (result === null) {
+      hasPosted.current = false;
+    }
+  }, [result]);
+
   useEffect(() => {
     hasPosted.current = false;
-  }, [drillId, resetKey]);
+  }, [drillId]);
 
   useEffect(() => {
     const canSave =


### PR DESCRIPTION
## Summary
- reset posting flag only when result resets or drill changes
- avoid triggering save on replay

## Testing
- `npm run lint`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bdf4c0ae8832a8b1c92fce09db208