### PR TITLE
Add Endgame Trainer page

### DIFF
--- a/docs/ENDGAME_TRAINER.md
+++ b/docs/ENDGAME_TRAINER.md
@@ -1,0 +1,37 @@
+# Feature Epic: Endgame Trainer
+
+## Overview
+
+The **Endgame Trainer** lets players practice critical theoretical endings.
+Users pick a scenario and play it out against the computer, repeating lines
+until the technique feels automatic.
+
+---
+
+## User Stories
+
+- **ET-US1**: As a user, I want to browse a list of common endgames so I can focus on specific patterns.
+- **ET-US2**: As a user, I want the engine to defend correctly so I learn proper conversion or drawing methods.
+- **ET-US3**: As a user, I want to reset the position after each attempt to drill it multiple times.
+- **ET-US4**: As a user, I want quick tips on the key motifs so I can recall them during practice.
+
+## Flow
+
+1. Navigate to **Training → Endgame Trainer**.
+2. Choose an ending from the list (e.g. Lucena, Philidor, basic mates).
+3. The board loads with the selected position and Stockfish plays the defensive side.
+4. The player tries to convert or hold the draw following best practice.
+5. After completion, show success/failure and offer to retry.
+
+## Tasks
+
+### Front-End
+
+1. Add a new route `/endgames` and menu entries in the sidebar and mobile navigation.
+2. Implement an `EndgameTrainer` page listing the available positions.
+3. Provide reset functionality and short instructional notes for each ending.
+
+### Back-End
+
+1. No server changes required initially; positions can be stored client side.
+2. Optionally record results for progress tracking in the future.

--- a/src/components/MobileGlobalNav.tsx
+++ b/src/components/MobileGlobalNav.tsx
@@ -7,6 +7,7 @@ import {
   useMotionValue,
 } from 'framer-motion';
 import {
+  Castle,
   Clock,
   Home,
   LayoutGrid,
@@ -65,6 +66,11 @@ export default function MobileGlobalNav() {
       label: 'Analyse',
       icon: <Upload className="h-5 w-5" />,
       path: '/analyse',
+    },
+    {
+      label: 'Endgames',
+      icon: <Castle className="h-5 w-5" />,
+      path: '/endgames',
     },
   ];
 

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import { Drawer } from 'flowbite-react';
 import { motion } from 'framer-motion';
+import { Castle } from 'lucide-react';
 
 import EasterEggCredits, { useRapidTaps } from './EasterEggCredits';
 
@@ -96,7 +97,14 @@ export default function Sidebar({ isSidebarOpen, closeSidebar }) {
     ),
   };
 
+  const endgamesNav = {
+    to: '/endgames',
+    label: 'Endgames',
+    Icon: ({ className }) => <Castle className={className} />,
+  };
+
   const bottomNav = [
+    endgamesNav,
     {
       to: '/help',
       label: 'Help',

--- a/src/pages/endgames/index.tsx
+++ b/src/pages/endgames/index.tsx
@@ -1,0 +1,69 @@
+import { Castle, Crown, Shield, Sword, Swords } from 'lucide-react';
+
+export default function EndgameTrainer() {
+  return (
+    <div className="p-4 pt-8 2xl:ml-12">
+      <div className="mx-auto max-w-2xl space-y-6">
+        <h1 className="text-3xl font-bold text-white">Endgame Trainer</h1>
+        <p className="text-stone-400">
+          Sharpen your technique with classic theoretical endings.
+        </p>
+        <ul className="space-y-8">
+          <li>
+            <h2 className="mb-2 flex items-center gap-2 text-xl font-semibold text-white">
+              <Crown className="h-5 w-5 text-green-500" /> King + Pawn vs. King
+            </h2>
+            <ul className="ml-8 list-disc space-y-1 text-stone-300">
+              <li>Basic opposition (key squares, distant opposition)</li>
+              <li>Outside vs. inside passed pawns</li>
+              <li>W-h pawns (a/h-file stalemates)</li>
+            </ul>
+          </li>
+          <li>
+            <h2 className="mb-2 flex items-center gap-2 text-xl font-semibold text-white">
+              <Castle className="h-5 w-5 text-green-500" /> Pawn Structures
+            </h2>
+            <ul className="ml-8 list-disc space-y-1 text-stone-300">
+              <li>Lucena position (winning with extra rook and pawn)</li>
+              <li>Philidor position (drawing with rook and pawn down)</li>
+              <li>Building a bridge</li>
+              <li>Wrong bishop + rook pawn draw</li>
+            </ul>
+          </li>
+          <li>
+            <h2 className="mb-2 flex items-center gap-2 text-xl font-semibold text-white">
+              <Sword className="h-5 w-5 text-green-500" /> King + Rook vs. King
+            </h2>
+            <ul className="ml-8 list-disc space-y-1 text-stone-300">
+              <li>Basic checkmate</li>
+              <li>Edge-check technique (cut-off method)</li>
+            </ul>
+          </li>
+          <li>
+            <h2 className="mb-2 flex items-center gap-2 text-xl font-semibold text-white">
+              <Swords className="h-5 w-5 text-green-500" /> King + Rook + Pawn
+              vs. King + Rook
+            </h2>
+            <ul className="ml-8 list-disc space-y-1 text-stone-300">
+              <li>Lucena vs. Philidor in rook endings</li>
+              <li>Short-side defence technique</li>
+              <li>Checking from behind and the side</li>
+            </ul>
+          </li>
+          <li>
+            <h2 className="mb-2 flex items-center gap-2 text-xl font-semibold text-white">
+              <Shield className="h-5 w-5 text-green-500" /> King + Bishop +
+              Knight vs. King
+            </h2>
+            <ul className="ml-8 list-disc space-y-1 text-stone-300">
+              <li>
+                Checkmate pattern (e.g. W-method) – rare, but worth one-time
+                training
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -8,6 +8,7 @@ import AnalyseGame from '@/pages/analyse';
 import Drills from '@/pages/drills';
 import PlayDrill from '@/pages/drills/components/PlayDrill';
 import RecentDrillsPage from '@/pages/drills/RecentDrillsPage';
+import EndgameTrainer from '@/pages/endgames';
 import GameHistory from '@/pages/games';
 import Help from '@/pages/help';
 import PreSignupHome from '@/pages/home/PreSignupHome';
@@ -76,6 +77,14 @@ export default function AppRoutes() {
         }
       />
       <Route path="/drills/play/:id" element={<PlayDrill />} />
+      <Route
+        path="/endgames"
+        element={
+          <ProtectedRoute>
+            <EndgameTrainer />
+          </ProtectedRoute>
+        }
+      />
       <Route
         path="/help"
         element={


### PR DESCRIPTION
## Summary
- create Endgame Trainer page listing common endings to practice
- hook up the new page in routes
- link Endgames from sidebar and mobile navigation

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684c095e607c832a8d0fc0e3ee31367f